### PR TITLE
Test the migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Chats that led me here: https://dapphub.chat/channel/dev?msg=SjN9jmkiXFuKaFqWM and https://dapphub.chat/channel/dev?msg=HnZi8PHXquyzZ35cX 
+# Chats that led me here: https://dapphub.chat/channel/dev?msg=SjN9jmkiXFuKaFqWM and https://dapphub.chat/channel/dev?msg=HnZi8PHXquyzZ35cX
 # So based it off of: https://github.com/centrifuge/tinlake-maker-lib/blob/c47b6e1b17e3e3d58036ad7356bec34370edccd4/.github/workflows/build.yml
 
 name: "Dapptools CI"
@@ -21,10 +21,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Checkout submodules
         run: git submodule update --init --recursive
-      - uses: cachix/install-nix-action@ef4324316b96b50b4671cecef9ecc6fd286f224a
-        with:
-          skip_adding_nixpkgs_channel: false        
-      - uses: cachix/cachix-action@6e4751ed42b22f60165d3f266cfa4cce66ae406d
+      - uses: cachix/install-nix-action@v14
+      - uses: cachix/cachix-action@v10
         with:
           name: dapp
           skipPush: true

--- a/contracts/migration/OlympusTokenMigrator.sol
+++ b/contracts/migration/OlympusTokenMigrator.sol
@@ -278,6 +278,7 @@ contract OlympusTokenMigrator is Ownable {
         oldTreasury.manage(token, balance);
 
         if(deposit) {
+            IERC20(token).safeApprove(address(newTreasury), balance);
             newTreasury.deposit(balance, token, tokenValue);
         } else {
             IERC20(token).transfer(address(newTreasury), balance);

--- a/test/migration/TreasuryTokenMigrator.js
+++ b/test/migration/TreasuryTokenMigrator.js
@@ -318,7 +318,6 @@ describe("Treasury Token Migration", async () => {
                 }
             }
             const contract = new ethers.Contract(newLPAddress, lpToken.abi, ethers.provider);
-            let balance = await contract.connect(deployer).balanceOf(OLD_TREASURY_ADDRESS);
             return {
                 name: lpToken.name,
                 isLP: true,
@@ -382,7 +381,7 @@ describe("Treasury Token Migration", async () => {
         await Promise.all(assertPromises);
     });
 
-    describe.skip("Defund", async () => {
+    describe("Defund", async () => {
         it("Should defund", async () => {
             let dai = treasury_tokens.find((token) => token.name === "dai");
 

--- a/test/migration/TreasuryTokenMigrator.js
+++ b/test/migration/TreasuryTokenMigrator.js
@@ -29,7 +29,7 @@ const is_sushi_lp = olympus_lp_tokens.map((lp_token) => lp_token.is_sushi);
 const lp_token_addresses = olympus_lp_tokens.map((lp_token) => lp_token.address);
 
 // TODO currently skipped
-describe.skip("Treasury Token Migration", async () => {
+describe("Treasury Token Migration", async () => {
     let deployer,
         user1,
         manager,
@@ -42,7 +42,8 @@ describe.skip("Treasury Token Migration", async () => {
         newTreasury,
         newStaking;
 
-    before(async () => {
+    before(async function () {
+        this.timeout(0); // disable timeout
         await fork_network(13487643);
         [deployer, user1] = await ethers.getSigners();
 
@@ -65,7 +66,6 @@ describe.skip("Treasury Token Migration", async () => {
             OLD_TREASURY_ADDRESS,
             OLD_STAKING_ADDRESS,
             OLD_WSOHM_ADDRESS,
-            DAI_ADDRESS,
             SUSHI_ROUTER,
             UNISWAP_ROUTER,
             1 // timelock for defunds
@@ -153,18 +153,17 @@ describe.skip("Treasury Token Migration", async () => {
     });
 
     it("Should fail if sender is not DAO", async () => {
+        let token = treasury_tokens[0];
         await expect(
-            olympusTokenMigrator.connect(user1).addTokens(tokenAddresses, reserveToken)
+            olympusTokenMigrator.connect(user1).migrateToken(token.address)
         ).to.revertedWith("Ownable: caller is not the owner");
+
+        let lpToken = olympus_lp_tokens[0];
 
         await expect(
             olympusTokenMigrator
                 .connect(user1)
-                .addLPTokens(lp_token_addresses, lp_token_0, lp_token_1, is_sushi_lp)
-        ).to.revertedWith("Ownable: caller is not the owner");
-
-        await expect(
-            olympusTokenMigrator.connect(user1).addTokens(tokenAddresses, reserveToken)
+                .migrateLP(lpToken.address, lpToken.is_sushi, lpToken.token0)
         ).to.revertedWith("Ownable: caller is not the owner");
     });
 
@@ -174,28 +173,6 @@ describe.skip("Treasury Token Migration", async () => {
         await expect(olympusTokenMigrator.connect(user).migrate(1000000, 0)).to.revertedWith(
             "ERC20: transfer amount exceeds balance"
         );
-    });
-
-    it("should fail if token is not equal to reserve token", async () => {
-        await expect(
-            olympusTokenMigrator.connect(deployer).addTokens(tokenAddresses, [true, true, true])
-        ).to.revertedWith("token array lengths do not match");
-
-        await expect(
-            olympusTokenMigrator
-                .connect(deployer)
-                .addLPTokens(lp_token_addresses, lp_token_0, lp_token_1, [true, true])
-        ).to.revertedWith("token array lengths do not match");
-    });
-
-    it("Should allow DAO add tokens", async () => {
-        await olympusTokenMigrator.connect(deployer).addTokens(tokenAddresses, reserveToken);
-    });
-
-    it("Should allow DAO add lp tokens", async () => {
-        await olympusTokenMigrator
-            .connect(deployer)
-            .addLPTokens(lp_token_addresses, lp_token_0, lp_token_1, is_sushi_lp);
     });
 
     it("Should fail if user does not have any of the ohm tokens to bridge back ", async () => {
@@ -304,19 +281,44 @@ describe.skip("Treasury Token Migration", async () => {
             allReserveandLP
         );
 
+        const lusd = treasury_tokens.find(t => t.name === "lusd");
+
         await olympusTokenMigrator
             .connect(deployer)
-            .migrateContracts(newTreasury.address, newStaking.address, ohm.address, sOhm.address);
+            .migrateContracts(newTreasury.address, newStaking.address, ohm.address, sOhm.address, lusd.address);
+
+        await olympus_lp_tokens.forEach(async lpToken => {
+          // console.log("migrating", lpToken.name);
+          await olympusTokenMigrator
+            .connect(deployer)
+            .migrateLP(lpToken.address, lpToken.is_sushi, lpToken.token0);
+        });
+
+        await treasury_tokens.forEach(async token => {
+          if (token.name !== "lusd" || token.name !== "dai") {
+            // console.log("migrating", token.name);
+            await olympusTokenMigrator
+                .connect(deployer)
+                .migrateToken(token.address);
+          }
+        });
 
         const newLPTokensPromises = [...olympus_lp_tokens].map(async (lpToken) => {
             const asset0Address = lpToken.token0;
             let newLPAddress;
             if (lpToken.is_sushi) {
                 newLPAddress = await sushi_factory_contract.getPair(ohm.address, asset0Address);
+                if (newLPAddress === "0x0000000000000000000000000000000000000000") {
+                  newLPAddress = await sushi_factory_contract.getPair(asset0Address, ohm.address);
+                }
             } else {
                 newLPAddress = await uni_factory_contract.getPair(ohm.address, asset0Address);
+                if (newLPAddress === "0x0000000000000000000000000000000000000000") {
+                  newLPAddress = await uni_factory_contract.getPair(ohm.address, asset0Address);
+                }
             }
             const contract = new ethers.Contract(newLPAddress, lpToken.abi, ethers.provider);
+            let balance = await contract.connect(deployer).balanceOf(OLD_TREASURY_ADDRESS);
             return {
                 name: lpToken.name,
                 isLP: true,
@@ -380,7 +382,7 @@ describe.skip("Treasury Token Migration", async () => {
         await Promise.all(assertPromises);
     });
 
-    describe("Defund", async () => {
+    describe.skip("Defund", async () => {
         it("Should defund", async () => {
             let dai = treasury_tokens.find((token) => token.name === "dai");
 
@@ -422,7 +424,7 @@ describe.skip("Treasury Token Migration", async () => {
 
             await olympusTokenMigrator.connect(deployer).startTimelock();
             await advance(2);
-            await olympusTokenMigrator.connect(deployer).defund();
+            await olympusTokenMigrator.connect(deployer).defund(DAI_ADDRESS);
 
             const v2TreasuryBalanceNew = await dai.contract
                 .connect(deployer)
@@ -515,14 +517,14 @@ async function getTreasuryBalance(deployer, newTreasuryAddress, tokens) {
             .balanceOf(OLD_TREASURY_ADDRESS);
         v1Treasury[tokenName] = v1TreasuryBalance.toString();
         //DEBUG
-        //console.log(`v1Treasury_${tokenName}_balance`, v1TreasuryBalance.toString());
+        // console.log(`v1Treasury_${tokenName}_balance`, v1TreasuryBalance.toString());
 
         const newTreasuryBalance = await tokenContract
             .connect(deployer)
             .balanceOf(newTreasuryAddress);
         v2Treasury[tokenName] = newTreasuryBalance.toString();
         // DEBUG
-        //console.log(`v2treasury_${tokenName}_balance`, newTreasuryBalance.toString());
+        // console.log(`v2treasury_${tokenName}_balance`, newTreasuryBalance.toString());
     }
     return { v1Treasury, v2Treasury };
 }

--- a/test/migration/tokens.js
+++ b/test/migration/tokens.js
@@ -55,6 +55,90 @@ const treasury_tokens = [
         abi: dai_abi,
         isReserve: true,
     },
+    // TODO: xSUSHI
+    // {
+    //     name: "xsushi",
+    //     address: "0x8798249c2e607446efb7ad49ec89dd1865ff4272",
+    //     abi: xsushi_abi,
+    //     isReserve: false,
+    // }
+    // TODO: SPELL
+    // {
+    //     name: "spell",
+    //     address: "0x090185f2135308bad17527004364ebcc2d37e5f6",
+    //     abi: spell_abi,
+    //     isReserve: false,
+    // }
+    // TODO: CVX
+    // {
+    //     name: "cvx",
+    //     address: "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+    //     abi: cvx_abi,
+    //     isReserve: false,
+    // }
+    // TODO: ALCX
+    // {
+    //     name: "alcx",
+    //     address: "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+    //     abi: alcx_abi,
+    //     isReserve: false,
+    // }
+    // TODO: FXS
+    // {
+    //     name: "fxs",
+    //     address: "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
+    //     abi: fxs_abi,
+    //     isReserve: false,
+    // }
+    // TODO: CRV
+    // {
+    //     name: "crv",
+    //     address: "0xd533a949740bb3306d119cc777fa900ba034cd52",
+    //     abi: crv_abi,
+    //     isReserve: false,
+    // }
+    // TODO: PENDLE
+    // {
+    //     name: "pendle",
+    //     address: "0x808507121b80c02388fad14726482e061b8da827",
+    //     abi: pendle_abi,
+    //     isReserve: false,
+    // }
+    // TODO: BANK
+    // {
+    //     name: "bank",
+    //     address: "0x24a6a37576377f63f194caa5f518a60f45b42921",
+    //     abi: bank_abi,
+    //     isReserve: false,
+    // }
+    // TODO: XRUNE
+    // {
+    //     name: "xrune",
+    //     address: "0x69fa0fee221ad11012bab0fdb45d444d3d2ce71c",
+    //     abi: xrune_abi,
+    //     isReserve: false,
+    // }
+    // TODO: FOX
+    // {
+    //     name: "fox",
+    //     address: "0xc770eefad204b5180df6a14ee197d99d808ee52d",
+    //     abi: fox_abi,
+    //     isReserve: false,
+    // }
+    // TODO: SYN
+    // {
+    //     name: "syn",
+    //     address: "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
+    //     abi: syn_abi,
+    //     isReserve: false,
+    // }
+    // TODO: INV
+    // {
+    //     name: "inv",
+    //     address: "0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68",
+    //     abi: inv_abi,
+    //     isReserve: false,
+    // }
 ];
 
 const olympus_tokens = [


### PR DESCRIPTION
Covers migrateContracts, migrateToken and migrateLP.

Defund is still skipped.

Adds a call to `safeApprove` before calling deposit, as it was throwing
errors.

Makes TODOs for the rest of the assets in the treasury.