### PR TITLE
Fixed up some of the busted tests

### DIFF
--- a/test/migration/TreasuryTokenMigrator.js
+++ b/test/migration/TreasuryTokenMigrator.js
@@ -60,7 +60,7 @@ describe("Treasury Token Migration", async function () {
         ohm = await ohmContract.deploy(authority.address);
 
         let sOhmContract = await ethers.getContractFactory("sOlympus");
-        sOhm = await sOhmContract.connect(deployer).deploy(authority.address);
+        sOhm = await sOhmContract.connect(deployer).deploy();
 
         let newTreasuryContract = await ethers.getContractFactory("OlympusTreasury");
         newTreasury = await newTreasuryContract.deploy(ohm.address, 10, authority.address);
@@ -99,7 +99,8 @@ describe("Treasury Token Migration", async function () {
             gOhm.address,
             EPOCH_LEGNTH,
             0,
-            0
+            0,
+            
         );
 
         // Initialize staking

--- a/test/tokens/Ohm.test.ts
+++ b/test/tokens/Ohm.test.ts
@@ -2,7 +2,11 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 
-import { OlympusERC20Token, OlympusERC20Token__factory } from '../../types'
+import {
+  OlympusERC20Token,
+  OlympusERC20Token__factory,
+  OlympusAuthority__factory
+} from '../../types';
 
 describe("OlympusTest", () => {
   let deployer: SignerWithAddress;
@@ -14,8 +18,7 @@ describe("OlympusTest", () => {
   beforeEach(async () => {
     [deployer, vault, bob, alice] = await ethers.getSigners();
 
-    const Authority = await ethers.getContractFactory("OlympusAuthority");
-    const authority = await Authority.deploy(deployer, deployer, deployer, vault);
+    const authority = await (new OlympusAuthority__factory(deployer)).deploy(deployer.address, deployer.address, deployer.address, vault.address);
     await authority.deployed();
 
     ohm = await (new OlympusERC20Token__factory(deployer)).deploy(authority.address);

--- a/test/tokens/sOhm.test.ts
+++ b/test/tokens/sOhm.test.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { deployMockContract } from "ethereum-waffle";
 import { FakeContract, smock } from '@defi-wonderland/smock'
 
 import {
@@ -16,6 +15,8 @@ import {
   GOHM__factory,
   OlympusStaking,
   OlympusStaking__factory,
+  OlympusAuthority__factory,
+  OlympusAuthority
 } from '../../types';
 
 const TOTAL_GONS = 5000000000000000;
@@ -35,10 +36,9 @@ describe("sOhm", () => {
     stakingFake = await smock.fake<IStaking>('IStaking');
     gOhmFake = await smock.fake<GOHM>('gOHM');
 
-    const Authority = await ethers.getContractFactory("OlympusAuthority");
-    const authority = await Authority.deploy(initializer, initializer, initializer, initializer);
-    await authority.deployed();
 
+    const Authority = await ethers.getContractFactory("OlympusAuthority");
+    const authority = await (new OlympusAuthority__factory(initializer)).deploy(initializer.address, initializer.address, initializer.address, initializer.address);
     ohm = await (new OlympusERC20Token__factory(initializer)).deploy(authority.address);
     sOhm = await (new SOlympus__factory(initializer)).deploy();
   });


### PR DESCRIPTION
The migrator tests are still broken though. `setVault` is no longer a function on `OHM`, but once I remove that call, the `migrateContracts` function fails because only the vault can mint.