### PR TITLE
minor changes

### DIFF
--- a/contracts/governance/gOHM.sol
+++ b/contracts/governance/gOHM.sol
@@ -9,6 +9,7 @@ import "../interfaces/IgOHM.sol";
 import "../types/ERC20.sol";
 
 contract gOHM is IgOHM, ERC20 {
+
     /* ========== DEPENDENCIES ========== */
 
     using Address for address;
@@ -75,7 +76,6 @@ contract gOHM is IgOHM, ERC20 {
         sOHM = IsOHM(_sOHM);
     }
 
-
     /**
      * @notice Delegate votes from `msg.sender` to `delegatee`
      * @param delegatee The address to delegate votes to
@@ -128,7 +128,6 @@ contract gOHM is IgOHM, ERC20 {
     function balanceTo(uint256 _amount) public view override returns (uint256) {
         return _amount.mul(10**decimals()).div(index());
     }
-
 
     /**
      * @notice Gets the current votes balance for `account`

--- a/contracts/types/ERC20.sol
+++ b/contracts/types/ERC20.sol
@@ -92,12 +92,12 @@ abstract contract ERC20 is IERC20 {
         emit Transfer(sender, recipient, amount);
     }
 
-    function _mint(address account_, uint256 ammount_) internal virtual {
-        require(account_ != address(0), "ERC20: mint to the zero address");
-        _beforeTokenTransfer(address(0), account_, ammount_);
-        _totalSupply = _totalSupply.add(ammount_);
-        _balances[account_] = _balances[account_].add(ammount_);
-        emit Transfer(address(0), account_, ammount_);
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+        _beforeTokenTransfer(address(0), account, amount);
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
     }
 
     function _burn(address account, uint256 amount) internal virtual {

--- a/test/migration/TreasuryTokenMigrator.js
+++ b/test/migration/TreasuryTokenMigrator.js
@@ -181,7 +181,7 @@ describe("Treasury Token Migration", async function () {
         await expect(
             olympusTokenMigrator
                 .connect(user1)
-                .migrateLP(lpToken.address, lpToken.is_sushi, lpToken.token0)
+                .migrateLP(lpToken.address, lpToken.is_sushi, lpToken.token0, 0, 0)
         ).to.revertedWith("UNAUTHORIZED");
     });
 
@@ -365,7 +365,7 @@ describe("Treasury Token Migration", async function () {
             // console.log("migrating", lpToken.name);
             await olympusTokenMigrator
                 .connect(deployer)
-                .migrateLP(lpToken.address, lpToken.is_sushi, lpToken.token0);
+                .migrateLP(lpToken.address, lpToken.is_sushi, lpToken.token0, 0, 0);
         });
 
         await treasury_tokens.forEach(async (token) => {


### PR DESCRIPTION
transfer -> safeTransfer on some functions.

add redundant migrated requirement to migrate func.

pass min amounts for migrateLP instead of hardcoded 0's (shouldn't matter but doesn't hurt)

fix a typo on ERC20.sol

delete some spaces on gOHM