### PR TITLE
constant product value of bonding converter should work for non standard reserves with 6 digit fraction like USDC.m

### DIFF
--- a/contracts/StandardBondingCalculator.sol
+++ b/contracts/StandardBondingCalculator.sol
@@ -275,10 +275,18 @@ contract OlympusBondingCalculator is IBondingCalculator {
     function getKValue( address _pair ) public view returns( uint k_ ) {
         uint token0 = IERC20( IUniswapV2Pair( _pair ).token0() ).decimals();
         uint token1 = IERC20( IUniswapV2Pair( _pair ).token1() ).decimals();
-        uint decimals = token0.add( token1 ).sub( IERC20( _pair ).decimals() );
 
         (uint reserve0, uint reserve1, ) = IUniswapV2Pair( _pair ).getReserves();
-        k_ = reserve0.mul(reserve1).div( 10 ** decimals );
+        uint reserveDecimals = token0.add( token1 );
+        uint pairDecimals = IERC20( _pair ).decimals();
+
+        if (reserveDecimals >= pairDecimals) {
+            uint decimals = reserveDecimals.sub( pairDecimals );
+            k_ = reserve0.mul(reserve1).div( 10 ** decimals );
+        } else {
+            uint decimals = pairDecimals.sub( reserveDecimals );
+            k_ = reserve0.mul(reserve1).mul( 10 ** decimals );
+        }
     }
 
     function getTotalValue( address _pair ) public view returns ( uint _value ) {


### PR DESCRIPTION
Everything is written that you cannot need to know digits of ERC20 assets from which LP token is created - except KValue.

For example if you have OHM token 9 digit fraction and some non standard stable-coin asset like USDC.m bridged with Wan Chain with 6 digit fraction original calculation is negative.

Repair is fairly simple. Question is whether you want to have this in StandardBondingCalculator or whether to have it in your branch 1.1.