### PR TITLE
use base supply

### DIFF
--- a/contracts/BondDepository.sol
+++ b/contracts/BondDepository.sol
@@ -392,7 +392,7 @@ contract OlympusBondDepository is OlympusAccessControlled {
    * @return debtRatio_ uint
    */
   function debtRatio(uint256 _BID) public view returns (uint256 debtRatio_) {
-    debtRatio_ = FixedPoint.fraction(currentDebt(_BID).mul(1e9), treasury.baseSupply()).decode112with18().div(1e18);
+    debtRatio_ = FixedPoint.fraction(currentDebt(_BID).mul(1e9), treasury.baseSupply()).decode112with18().div(1e18); 
   }
 
   /**

--- a/contracts/BondDepository.sol
+++ b/contracts/BondDepository.sol
@@ -318,7 +318,7 @@ contract OlympusBondDepository is OlympusAccessControlled {
    * @return uint
    */
   function maxPayout(uint256 _BID) public view returns (uint256) {
-    return OHM.totalSupply().mul(bonds[_BID].terms.maxPayout).div(100000);
+    return treasury.baseSupply().mul(bonds[_BID].terms.maxPayout).div(100000);
   }
 
   /**
@@ -392,7 +392,7 @@ contract OlympusBondDepository is OlympusAccessControlled {
    * @return debtRatio_ uint
    */
   function debtRatio(uint256 _BID) public view returns (uint256 debtRatio_) {
-    debtRatio_ = FixedPoint.fraction(currentDebt(_BID).mul(1e9), OHM.totalSupply()).decode112with18().div(1e18);
+    debtRatio_ = FixedPoint.fraction(currentDebt(_BID).mul(1e9), treasury.baseSupply()).decode112with18().div(1e18);
   }
 
   /**

--- a/contracts/StakingDistributor.sol
+++ b/contracts/StakingDistributor.sol
@@ -115,7 +115,7 @@ contract Distributor is IDistributor, OlympusAccessControlled {
         @return uint
      */
     function nextRewardAt(uint256 _rate) public view override returns (uint256) {
-        return ohm.totalSupply().mul(_rate).div(rateDenominator);
+        return treasury.baseSupply().mul(_rate).div(rateDenominator);
     }
 
     /**

--- a/contracts/StakingDistributor.sol
+++ b/contracts/StakingDistributor.sol
@@ -115,7 +115,7 @@ contract Distributor is IDistributor, OlympusAccessControlled {
         @return uint
      */
     function nextRewardAt(uint256 _rate) public view override returns (uint256) {
-        return treasury.baseSupply().mul(_rate).div(rateDenominator);
+        return ohm.totalSupply().mul(_rate).div(rateDenominator);
     }
 
     /**

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -446,4 +446,12 @@ contract OlympusTreasury is OlympusAccessControlled, ITreasury {
             value_ = IBondingCalculator(bondCalculator[_token]).valuation(_token, _amount);
         }
     }
+
+    /**
+     * @notice returns supply metric that cannot be manipulated by debt
+     * @dev use this any time you need to query supply
+     */
+    function baseSupply() external view override returns (uint256) {
+        return OHM.totalSupply() - totalDebt;
+    }
 }

--- a/contracts/interfaces/ITreasury.sol
+++ b/contracts/interfaces/ITreasury.sol
@@ -21,4 +21,6 @@ interface ITreasury {
     function repayDebtWithReserve(uint256 amount_, address token_) external;
 
     function excessReserves() external view returns (uint256);
+
+    function baseSupply() external view returns (uint256);
 }


### PR DESCRIPTION
if contracts are allowed to borrow OHM against sOHM, totalSupply() becomes manipulable. base supply removes this from accounting, making it a safer metric for distributor and bonds.