### PR TITLE
use the `gonsForBalance` function in `transfer` function of sOlympusE…

### DIFF
--- a/contracts/sOlympusERC20.sol
+++ b/contracts/sOlympusERC20.sol
@@ -1136,7 +1136,7 @@ contract sOlympus is ERC20Permit, Ownable {
     }
 
     function transfer( address to, uint256 value ) public override returns (bool) {
-        uint256 gonValue = value.mul( _gonsPerFragment );
+        uint256 gonValue = gonsForBalance(value);
         _gonBalances[ msg.sender ] = _gonBalances[ msg.sender ].sub( gonValue );
         _gonBalances[ to ] = _gonBalances[ to ].add( gonValue );
         emit Transfer( msg.sender, to, value );


### PR DESCRIPTION
…RC20.sol, instead of writing the code again

The first line of the `transfer` function in the sOlympusERC20.sol contract
calculates the gonValue of the given fragments represented by the
`value` parameter.

The contract has a function `gonsForBalance` for this purpose and using
this can help maintain consistency in the codebase and can help avoid
any bugs in the future if `gonsForBalance` goes through some change!

old code =>

```
uint256 gonValue = value.mul( _gonsPerFragment );
```

new change =>

```
uint256 gonValue = gonsForBalance(value);
```