### PR TITLE
feat: YieldStreamer and YieldSplitter Contract

### DIFF
--- a/contracts/interfaces/IUniswapV2Router.sol
+++ b/contracts/interfaces/IUniswapV2Router.sol
@@ -36,4 +36,26 @@ interface IUniswapV2Router {
         address to,
         uint256 deadline
     ) external returns (uint256 amountA, uint256 amountB);
+
+    function quote(
+        uint256 amountA,
+        uint256 reserveA,
+        uint256 reserveB
+    ) external pure returns (uint256 amountB);
+
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountOut);
+
+    function getAmountIn(
+        uint256 amountOut,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountIn);
+
+    function getAmountsOut(uint256 amountIn, address[] calldata path) external view returns (uint256[] memory amounts);
+
+    function getAmountsIn(uint256 amountOut, address[] calldata path) external view returns (uint256[] memory amounts);
 }

--- a/contracts/interfaces/IYieldStreamer.sol
+++ b/contracts/interfaces/IYieldStreamer.sol
@@ -16,6 +16,8 @@ interface IYieldStreamer {
 
     function withdrawYield(uint256 id_) external;
 
+    function withdrawAllYield() external;
+
     function withdrawYieldInStreamTokens(uint256 id_) external;
 
     function harvestStreamTokens(uint256 id_) external;

--- a/contracts/interfaces/IYieldStreamer.sol
+++ b/contracts/interfaces/IYieldStreamer.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+interface IYieldStreamer {
+    // Write Functions
+    function deposit(
+        uint256 amount_,
+        address recipient_,
+        uint256 paymentInterval_,
+        uint256 userMinimumDaiThreshold_
+    ) external;
+
+    function addToDeposit(uint256 id_, uint256 amount_) external;
+
+    function withdrawPrincipal(uint256 id_, uint256 amount_) external;
+
+    function withdrawYield(uint256 id_) external;
+
+    function withdrawYieldAsDai(uint256 id_) external;
+
+    function harvestDai(uint256 id_) external;
+
+    function updateUserMinDaiThreshold(uint256 id_, uint256 threshold_) external;
+
+    function updatePaymentInterval(uint256 id_, uint256 paymentInterval) external;
+
+    function upkeep() external;
+
+    // View Functions
+    function upkeepEligibility() external view returns (uint256 numberOfDepositsEligible, uint256 amountOfYieldToSwap);
+
+    function getOutstandingYield(uint256 id_) external view returns (uint256);
+
+    function getPrincipalInGOHM(uint256 id_) external view returns (uint256);
+
+    function getTotalHarvestableYieldGOHM(address recipient_) external view returns (uint256 totalGOHM);
+}

--- a/contracts/interfaces/IYieldStreamer.sol
+++ b/contracts/interfaces/IYieldStreamer.sol
@@ -6,8 +6,8 @@ interface IYieldStreamer {
     function deposit(
         uint256 amount_,
         address recipient_,
-        uint256 paymentInterval_,
-        uint256 userMinimumDaiThreshold_
+        uint128 paymentInterval_,
+        uint128 userMinimumDaiThreshold_
     ) external;
 
     function addToDeposit(uint256 id_, uint256 amount_) external;
@@ -20,9 +20,9 @@ interface IYieldStreamer {
 
     function harvestStreamTokens(uint256 id_) external;
 
-    function updateUserMinDaiThreshold(uint256 id_, uint256 threshold_) external;
+    function updateUserMinDaiThreshold(uint256 id_, uint128 threshold_) external;
 
-    function updatePaymentInterval(uint256 id_, uint256 paymentInterval) external;
+    function updatePaymentInterval(uint256 id_, uint128 paymentInterval) external;
 
     function upkeep() external;
 

--- a/contracts/interfaces/IYieldStreamer.sol
+++ b/contracts/interfaces/IYieldStreamer.sol
@@ -36,4 +36,8 @@ interface IYieldStreamer {
     function getPrincipalInGOHM(uint256 id_) external view returns (uint256);
 
     function getTotalHarvestableYieldGOHM(address recipient_) external view returns (uint256 totalGOHM);
+
+    function getRecipientIds(address recipient_) external view returns (uint256[] memory);
+
+    function getDepositorIds(address donor_) external view returns (uint256[] memory);
 }

--- a/contracts/interfaces/IYieldStreamer.sol
+++ b/contracts/interfaces/IYieldStreamer.sol
@@ -16,9 +16,9 @@ interface IYieldStreamer {
 
     function withdrawYield(uint256 id_) external;
 
-    function withdrawYieldAsDai(uint256 id_) external;
+    function withdrawYieldInStreamTokens(uint256 id_) external;
 
-    function harvestDai(uint256 id_) external;
+    function harvestStreamTokens(uint256 id_) external;
 
     function updateUserMinDaiThreshold(uint256 id_, uint256 threshold_) external;
 

--- a/contracts/mocks/YieldSplitterImplementation.sol
+++ b/contracts/mocks/YieldSplitterImplementation.sol
@@ -30,7 +30,7 @@ contract YieldSplitterImpl is YieldSplitter {
         @param amount_ Amount of gOhm to add. 18 decimals.
     */
     function addToDeposit(uint256 id_, uint256 amount_) external {
-        _addToDeposit(id_, amount_);
+        _addToDeposit(id_, amount_, msg.sender);
     }
 
     /**
@@ -39,7 +39,7 @@ contract YieldSplitterImpl is YieldSplitter {
         @param amount_ Amount of gOHM to withdraw.
     */
     function withdrawPrincipal(uint256 id_, uint256 amount_) external {
-        _withdrawPrincipal(id_, amount_);
+        _withdrawPrincipal(id_, amount_, msg.sender);
     }
 
     /**
@@ -48,7 +48,7 @@ contract YieldSplitterImpl is YieldSplitter {
         @return amountWithdrawn : amount of gOHM withdrawn. 18 decimals.
     */
     function withdrawAllPrincipal(uint256 id_) external returns (uint256 amountWithdrawn) {
-        return _withdrawAllPrincipal(id_);
+        return _withdrawAllPrincipal(id_, msg.sender);
     }
 
     /**
@@ -70,7 +70,7 @@ contract YieldSplitterImpl is YieldSplitter {
         @return agnosticAmount : total amount of gOHM deleted. Principal + Yield. 18 decimals.
     */
     function closeDeposit(uint256 id_) external returns (uint256 principal, uint256 agnosticAmount) {
-        (principal, agnosticAmount) = _closeDeposit(id_);
+        (principal, agnosticAmount) = _closeDeposit(id_, msg.sender);
     }
 
     /**

--- a/contracts/mocks/YieldSplitterImplementation.sol
+++ b/contracts/mocks/YieldSplitterImplementation.sol
@@ -11,9 +11,9 @@ import {IgOHM} from "../interfaces/IgOHM.sol";
 contract YieldSplitterImpl is YieldSplitter {
     /**
     @notice Constructor
-    @param gOHM_ Address of gOHM.
+    @param sOHM_ Address of gOHM.
     */
-    constructor(address gOHM_) YieldSplitter(gOHM_) {}
+    constructor(address sOHM_) YieldSplitter(sOHM_) {}
 
     /**
         @notice Create a deposit.
@@ -26,7 +26,7 @@ contract YieldSplitterImpl is YieldSplitter {
         address recipient_,
         uint256 amount_
     ) external returns (uint256 depositId) {
-        depositId = _deposit(depositor_, recipient_, amount_);
+        depositId = _deposit(depositor_, amount_);
     }
 
     /**
@@ -48,6 +48,15 @@ contract YieldSplitterImpl is YieldSplitter {
     }
 
     /**
+        @notice Withdraw all of the principal amount deposited.
+        @param id_ Id of the deposit.
+        @return amountWithdrawn : amount of gOHM withdrawn. 18 decimals.
+    */
+    function withdrawAllPrincipal(uint256 id_) external returns (uint256 amountWithdrawn) {
+        return _withdrawAllPrincipal(id_);
+    }
+
+    /**
         @notice Redeem excess yield from your deposit in sOHM.
         @param id_ Id of the deposit.
         @return amountRedeemed : amount of yield redeemed in gOHM. 18 decimals.
@@ -55,15 +64,6 @@ contract YieldSplitterImpl is YieldSplitter {
     function redeemYield(uint256 id_) external returns (uint256) {
         uint256 amountRedeemed = _redeemYield(id_);
         return amountRedeemed;
-    }
-
-    /**
-        @notice Redeem all excess yield from your all deposits recipient can redeem from.
-        @param recipient_ Recipient that wants to redeem their yield.
-        @return amountRedeemed : amount of yield redeemed in gOHM. 18 decimals.
-    */
-    function redeemAllYield(address recipient_) external returns (uint256 amountRedeemed) {
-        amountRedeemed = _redeemAllYield(recipient_);
     }
 
     /**

--- a/contracts/mocks/YieldSplitterImplementation.sol
+++ b/contracts/mocks/YieldSplitterImplementation.sol
@@ -11,7 +11,7 @@ import {IgOHM} from "../interfaces/IgOHM.sol";
 contract YieldSplitterImpl is YieldSplitter {
     /**
     @notice Constructor
-    @param sOHM_ Address of gOHM.
+    @param sOHM_ Address of sOHM.
     */
     constructor(address sOHM_) YieldSplitter(sOHM_) {}
 
@@ -19,13 +19,8 @@ contract YieldSplitterImpl is YieldSplitter {
         @notice Create a deposit.
         @param depositor_ Address of depositor
         @param amount_ Amount in gOhm. 18 decimals.
-        @param recipient_ Address to direct staking yield to.
     */
-    function deposit(
-        address depositor_,
-        address recipient_,
-        uint256 amount_
-    ) external returns (uint256 depositId) {
+    function deposit(address depositor_, uint256 amount_) external returns (uint256 depositId) {
         depositId = _deposit(depositor_, amount_);
     }
 

--- a/contracts/mocks/YieldSplitterImplementation.sol
+++ b/contracts/mocks/YieldSplitterImplementation.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+import {YieldSplitter} from "../types/YieldSplitter.sol";
+import {IgOHM} from "../interfaces/IgOHM.sol";
+
+/**
+    @title YieldSplitterImpl
+    @notice Implements the abstract contract Yield Splitter by making all the internal functions public for testing purposes.
+*/
+contract YieldSplitterImpl is YieldSplitter {
+    /**
+    @notice Constructor
+    @param gOHM_ Address of gOHM.
+    */
+    constructor(address gOHM_) YieldSplitter(gOHM_) {}
+
+    /**
+        @notice Create a deposit.
+        @param depositor_ Address of depositor
+        @param amount_ Amount in gOhm. 18 decimals.
+        @param recipient_ Address to direct staking yield to.
+    */
+    function deposit(
+        address depositor_,
+        address recipient_,
+        uint256 amount_
+    ) external returns (uint256 depositId) {
+        depositId = _deposit(depositor_, recipient_, amount_);
+    }
+
+    /**
+        @notice Add more gOhm to the depositor's principal deposit.
+        @param id_ Id of the deposit.
+        @param amount_ Amount of gOhm to add. 18 decimals.
+    */
+    function addToDeposit(uint256 id_, uint256 amount_) external {
+        _addToDeposit(id_, amount_);
+    }
+
+    /**
+        @notice Withdraw part of the principal amount deposited.
+        @param id_ Id of the deposit.
+        @param amount_ Amount of gOHM to withdraw.
+    */
+    function withdrawPrincipal(uint256 id_, uint256 amount_) external {
+        _withdrawPrincipal(id_, amount_);
+    }
+
+    /**
+        @notice Redeem excess yield from your deposit in sOHM.
+        @param id_ Id of the deposit.
+        @return amountRedeemed : amount of yield redeemed in gOHM. 18 decimals.
+    */
+    function redeemYield(uint256 id_) external returns (uint256) {
+        uint256 amountRedeemed = _redeemYield(id_);
+        return amountRedeemed;
+    }
+
+    /**
+        @notice Redeem all excess yield from your all deposits recipient can redeem from.
+        @param recipient_ Recipient that wants to redeem their yield.
+        @return amountRedeemed : amount of yield redeemed in gOHM. 18 decimals.
+    */
+    function redeemAllYield(address recipient_) external returns (uint256 amountRedeemed) {
+        amountRedeemed = _redeemAllYield(recipient_);
+    }
+
+    /**
+        @notice Close a deposit. Remove all information in both the deposit info, depositorIds and recipientIds.
+        @param id_ Id of the deposit.
+        @dev Internally for accounting reasons principal amount is stored in 9 decimal OHM terms. 
+        Since most implementations will work will gOHM, principal here is returned externally in 18 decimal gOHM terms.
+        @return principal : amount of principal that was deleted. in gOHM. 18 decimals.
+        @return agnosticAmount : total amount of gOHM deleted. Principal + Yield. 18 decimals.
+    */
+    function closeDeposit(uint256 id_) external returns (uint256 principal, uint256 agnosticAmount) {
+        (principal, agnosticAmount) = _closeDeposit(id_);
+    }
+
+    /**
+        @notice Calculate outstanding yield redeemable based on principal and agnosticAmount.
+        @return uint256 amount of yield in gOHM. 18 decimals.
+     */
+    function getOutstandingYield(uint256 principal_, uint256 agnosticAmount_) external view returns (uint256) {
+        return _getOutstandingYield(principal_, agnosticAmount_);
+    }
+}

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -117,8 +117,6 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         if (amount_ <= 0) revert InvalidAmount();
         if (userMinimumDaiThreshold_ < minimumDaiThreshold) revert MinDaiThresholdTooLow();
 
-        IERC20(gOHM).safeTransferFrom(msg.sender, address(this), amount_);
-
         uint256 depositId = _deposit(msg.sender, amount_);
 
         recipientInfo[depositId] = RecipientInfo({
@@ -132,6 +130,8 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         activeDepositIds.push(depositId);
         recipientIds[recipient_].push(depositId);
 
+        IERC20(gOHM).safeTransferFrom(msg.sender, address(this), amount_);
+
         emit Deposited(msg.sender, amount_);
     }
 
@@ -142,11 +142,11 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
     */
     function addToDeposit(uint256 id_, uint256 amount_) external override {
         if (depositDisabled) revert DepositDisabled();
-        // Protect customer from depositing into anothet addresses deposit?
-
-        IERC20(gOHM).safeTransferFrom(msg.sender, address(this), amount_);
+        if (depositInfo[id_].depositor != msg.sender) revert UnauthorisedAction();
 
         _addToDeposit(id_, amount_);
+
+        IERC20(gOHM).safeTransferFrom(msg.sender, address(this), amount_);
 
         emit Deposited(msg.sender, amount_);
     }

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -405,6 +405,22 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         return block.timestamp >= recipientInfo[id_].lastUpkeepTimestamp + recipientInfo[id_].paymentInterval;
     }
 
+    /**
+        @notice Returns the array of deposit id's belonging to the recipient
+        @return uint256[] array of recipient Id's
+     */
+    function getRecipientIds(address recipient_) external view returns (uint256[] memory) {
+        return recipientIds[recipient_];
+    }
+
+    /**
+        @notice Returns the array of deposit id's belonging to the depositor
+        @return uint256[] array of depositor Id's
+     */
+    function getDepositorIds(address donor_) external view returns (uint256[] memory) {
+        return depositorIds[donor_];
+    }
+
     /************************
      * Restricted Setter Functions
      ************************/

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -166,20 +166,22 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
             (uint256 principal, uint256 totalGOHM) = _closeDeposit(id_, msg.sender);
             delete recipientInfo[id_];
 
-            for (uint256 i = 0; i < activeDepositIds.length; i++) {
+            uint256 depositLength = activeDepositIds.length;
+            for (uint256 i = 0; i < depositLength; i++) {
                 // Delete integer from array by swapping with last element and calling pop()
                 if (activeDepositIds[i] == id_) {
-                    activeDepositIds[i] = activeDepositIds[activeDepositIds.length - 1];
+                    activeDepositIds[i] = activeDepositIds[depositLength - 1];
                     activeDepositIds.pop();
                     break;
                 }
             }
 
             uint256[] storage recipientIdsArray = recipientIds[recipient];
-            for (uint256 i = 0; i < recipientIdsArray.length; i++) {
+            uint256 recipientLength = recipientIdsArray.length;
+            for (uint256 i = 0; i < recipientLength; i++) {
                 // Delete integer from array by swapping with last element and calling pop()
                 if (recipientIdsArray[i] == id_) {
-                    recipientIdsArray[i] = recipientIdsArray[recipientIdsArray.length - 1];
+                    recipientIdsArray[i] = recipientIdsArray[recipientLength - 1];
                     recipientIdsArray.pop();
                     break;
                 }
@@ -303,8 +305,9 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         if (upkeepDisabled) revert YieldStreamer_UpkeepDisabled();
 
         uint256 totalGOHM;
+        uint256 depositLength = activeDepositIds.length;
 
-        for (uint256 i = 0; i < activeDepositIds.length; i++) {
+        for (uint256 i = 0; i < depositLength; i++) {
             uint256 currentId = activeDepositIds[i];
 
             if (_isUpkeepEligible(currentId)) {
@@ -327,7 +330,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
             block.timestamp
         );
 
-        for (uint256 i = 0; i < activeDepositIds.length; i++) {
+        for (uint256 i = 0; i < depositLength; i++) {
             // TODO: Is there a more gas efficient way than looping through this again and checking same condition
             uint256 currentId = activeDepositIds[i];
 

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -279,8 +279,10 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
     }
 
     /**
-        @notice Upkeeps all deposits if they are eligible to be upkept. Converts excess yield from gOHM to streamTokens. 
+        @notice Upkeeps all deposits if they are eligible.
+                Upkeep consists of converting all eligible deposits yield from gOhm into streamToken(usually DAI).
                 Sends the yield to recipient wallets if above user set threshold.
+                Eligible for upkeep means enough time(payment interval) has passed since their last upkeep.
     */
     function upkeep() external override {
         if (upkeepDisabled) revert YieldStreamer_UpkeepDisabled();
@@ -348,6 +350,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
 
     /**
         @notice Gets the number of deposits eligible for upkeep and amount of ohm of yield available to swap.
+                Eligible for upkeep means enough time(payment interval of deposit) has passed since last upkeep.
         @return numberOfDepositsEligible : number of deposits eligible for upkeep.
         @return amountOfYieldToSwap : total amount of yield in gOHM ready to be swapped in next upkeep.
      */
@@ -377,14 +380,12 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
     }
 
     /**
-        @notice Returns whether deposit id is eligible for upkeep
+        @notice Returns whether deposit id is eligible for upkeep.
+                Eligible for upkeep means enough time(payment interval of deposit) has passed since last upkeep.
         @return bool
      */
     function _isUpkeepEligible(uint256 id_) internal view returns (bool) {
-        if (block.timestamp >= recipientInfo[id_].lastUpkeepTimestamp + recipientInfo[id_].paymentInterval) {
-            return true;
-        }
-        return false;
+        return block.timestamp >= recipientInfo[id_].lastUpkeepTimestamp + recipientInfo[id_].paymentInterval;
     }
 
     /************************
@@ -393,19 +394,19 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
 
     /**
         @notice Setter for maxSwapSlippagePercent.
-        @param slippagePercent_ new slippage value as a fraction / 1000.
+        @param slippagePercent_ new slippage value is a percentage with 6 decimals. 1e6 = 100%
     */
     function setMaxSwapSlippagePercent(uint256 slippagePercent_) external onlyGovernor {
-        if (slippagePercent_ > 1000000) revert YieldStreamer_InvalidAmount();
+        if (slippagePercent_ > 1e6) revert YieldStreamer_InvalidAmount();
         maxSwapSlippagePercent = slippagePercent_;
     }
 
     /**
         @notice Setter for feeToDaoPercent.
-        @param feePercent_ new fee value as a fraction / 1000.
+        @param feePercent_ new fee value is a percentage with 6 decimals. 1e6 = 100%
     */
     function setFeeToDaoPercent(uint256 feePercent_) external onlyGovernor {
-        if (feePercent_ > 1000000) revert YieldStreamer_InvalidAmount();
+        if (feePercent_ > 1e6) revert YieldStreamer_InvalidAmount();
         feeToDaoPercent = feePercent_;
     }
 

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -207,11 +207,26 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         if (withdrawDisabled) revert YieldStreamer_WithdrawDisabled();
         if (recipientInfo[id_].recipientAddress != msg.sender) revert YieldStreamer_UnauthorisedAction();
 
-        recipientInfo[id_].lastUpkeepTimestamp = uint128(block.timestamp);
-
         uint256 yield = _redeemYield(id_);
 
         IERC20(gOHM).safeTransfer(msg.sender, yield);
+    }
+
+    /**
+        @notice Withdraw all excess yield from your all deposits you are the recipient of in gOHM.
+        @dev  Use withdrawYieldInStreamTokens() to withdraw yield in stream tokens.
+    */
+    function withdrawAllYield() external override {
+        if (withdrawDisabled) revert YieldStreamer_WithdrawDisabled();
+
+        uint256 total;
+        uint256[] memory receiptIds = recipientIds[msg.sender];
+
+        for (uint256 i = 0; i < receiptIds.length; i++) {
+            total += _redeemYield(receiptIds[i]);
+        }
+
+        IERC20(gOHM).safeTransfer(msg.sender, total);
     }
 
     /**

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+import {IERC20} from "../interfaces/IERC20.sol";
+import {IgOHM} from "../interfaces/IgOHM.sol";
+import {SafeERC20} from "../libraries/SafeERC20.sol";
+import {IYieldStreamer} from "../interfaces/IYieldStreamer.sol";
+import {OlympusAccessControlled, IOlympusAuthority} from "../types/OlympusAccessControlled.sol";
+import {IUniswapV2Router} from "../interfaces/IUniswapV2Router.sol";
+import {IStaking} from "../interfaces/IStaking.sol";
+import {YieldSplitter} from "../types/YieldSplitter.sol";
+
+/// Deposit function is disabled due to an emergency
+error DepositDisabled();
+/// Withdraw function is disabled due to an emergency
+error WithdrawDisabled();
+/// Upkeep function is disabled due to an emergency
+error UpkeepDisabled();
+/// User is trying to interact with a deposit that they do not own or is authorised to interact with
+error UnauthorisedAction();
+/// Input minimum dai threshold is below the minimum allowed
+error MinDaiThresholdTooLow();
+/// Cannot create a deposit with zero principal amount
+error InvalidAmount();
+
+/**
+    @title YieldStreamer
+    @notice This contract allows users to deposit their gOhm and have their yield
+            converted into DAI and sent to their address every interval.
+ */
+contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled {
+    using SafeERC20 for IERC20;
+
+    address public immutable OHM;
+    address public immutable DAI;
+    IUniswapV2Router public immutable sushiRouter;
+    address[] public sushiRouterPath = new address[](2);
+    IStaking public immutable staking;
+
+    bool public depositDisabled;
+    bool public withdrawDisabled;
+    bool public upkeepDisabled;
+
+    uint256 public maxSwapSlippagePercent; // as fraction / 1000
+    uint256 public feeToDaoPercent; // as fraction /1000
+    uint256 public minimumDaiThreshold;
+
+    struct UpkeepInfo {
+        uint256 lastUpkeepTimestamp;
+        uint256 paymentInterval; // Time before yield is able to be swapped to DAI
+        uint256 unclaimedDai;
+        uint256 userMinimumDaiThreshold;
+    }
+
+    mapping(uint256 => UpkeepInfo) public upkeepInfo; // depositId -> UpkeepInfo
+    uint256[] public activeDepositIds; // All deposit ids that are not empty or deleted
+
+    event Deposited(address indexed depositor_, uint256 amount_);
+    event Withdrawn(address indexed depositor_, uint256 amount_);
+    event UpkeepComplete(uint256 indexed timestamp);
+    event EmergencyShutdown(bool active_);
+
+    /**
+        @notice Constructor
+        @param gOHM_ Address of gOHM.
+        @param OHM_ Address of OHM.
+        @param DAI_ Address of DAO.
+        @param sushiRouter_ Address of sushiswap router.
+        @param staking_ Address of sOHM staking contract.
+        @param authority_ Address of Olympus authority contract.
+        @param maxSwapSlippagePercent_ Maximum acceptable slippage when swapping OHM to DAI as fraction / 1000.
+        @param feeToDaoPercent_ How much of yield goes to DAO before swapping to DAI as fraction / 1000.
+        @param minimumDaiThreshold_ Minimum a user can set threshold for amount of DAI accumulated as yield before sending to recipient's wallet.
+    */
+    constructor(
+        address gOHM_,
+        address OHM_,
+        address DAI_,
+        address sushiRouter_,
+        address staking_,
+        address authority_,
+        uint256 maxSwapSlippagePercent_,
+        uint256 feeToDaoPercent_,
+        uint256 minimumDaiThreshold_
+    ) YieldSplitter(gOHM_) OlympusAccessControlled(IOlympusAuthority(authority_)) {
+        OHM = OHM_;
+        DAI = DAI_;
+        sushiRouter = IUniswapV2Router(sushiRouter_);
+        staking = IStaking(staking_);
+        sushiRouterPath[0] = OHM;
+        sushiRouterPath[1] = DAI;
+        maxSwapSlippagePercent = maxSwapSlippagePercent_;
+        feeToDaoPercent = feeToDaoPercent_;
+        minimumDaiThreshold = minimumDaiThreshold_;
+    }
+
+    /**
+        @notice Deposit gOHM, creates a deposit in the active deposit pool to be unkept.
+        @param amount_ Amount of gOHM.
+        @param recipient_ Address to direct staking yield and vault shares to.
+        @param paymentInterval_ How much time must elapse before yield is able to be swapped for DAI.
+    */
+    function deposit(
+        uint256 amount_,
+        address recipient_,
+        uint256 paymentInterval_,
+        uint256 userMinimumDaiThreshold_
+    ) external override {
+        if (depositDisabled) revert DepositDisabled();
+        if (amount_ <= 0) revert InvalidAmount();
+        if (userMinimumDaiThreshold_ < minimumDaiThreshold) revert MinDaiThresholdTooLow();
+
+        IERC20(gOHM).safeTransferFrom(msg.sender, address(this), amount_);
+
+        uint256 depositId = _deposit(msg.sender, recipient_, amount_);
+
+        upkeepInfo[depositId] = UpkeepInfo({
+            lastUpkeepTimestamp: block.timestamp,
+            paymentInterval: paymentInterval_,
+            unclaimedDai: 0,
+            userMinimumDaiThreshold: userMinimumDaiThreshold_
+        });
+
+        activeDepositIds.push(depositId);
+
+        emit Deposited(msg.sender, amount_);
+    }
+
+    /**
+        @notice Add more gOHM to your principal deposit.
+        @param id_ Id of the deposit.
+        @param amount_ Amount of gOHM to add.
+    */
+    function addToDeposit(uint256 id_, uint256 amount_) external override {
+        if (depositDisabled) revert DepositDisabled();
+
+        IERC20(gOHM).safeTransferFrom(msg.sender, address(this), amount_);
+
+        _addToDeposit(id_, amount_);
+
+        emit Deposited(msg.sender, amount_);
+    }
+
+    /**
+        @notice Withdraw part or all of your principal amount deposited.
+        @dev If withdrawing all your principal, all accumulated yield will be sent to recipient and deposit will be closed.
+        @param id_ Id of the deposit.
+        @param amount_ Amount of gOHM to withdraw.
+    */
+    function withdrawPrincipal(uint256 id_, uint256 amount_) external override {
+        if (withdrawDisabled) revert WithdrawDisabled();
+        if (depositInfo[id_].depositor != msg.sender) revert UnauthorisedAction();
+
+        if (amount_ >= IgOHM(gOHM).balanceTo(depositInfo[id_].principalAmount)) {
+            address recipient = depositInfo[id_].recipient;
+            uint256 unclaimedDai = upkeepInfo[id_].unclaimedDai;
+            (uint256 principal, uint256 totalGOHM) = _closeDeposit(id_);
+            delete upkeepInfo[id_];
+
+            for (uint256 i = 0; i < activeDepositIds.length; i++) {
+                // Remove id_ from activeDepositIds
+                if (activeDepositIds[i] == id_) {
+                    activeDepositIds[i] = activeDepositIds[activeDepositIds.length - 1]; // Delete integer from array by swapping with last element and calling pop()
+                    activeDepositIds.pop();
+                    break;
+                }
+            }
+
+            IERC20(gOHM).safeTransfer(msg.sender, principal);
+            IERC20(gOHM).safeTransfer(recipient, totalGOHM - principal);
+            if (unclaimedDai != 0) {
+                IERC20(DAI).safeTransfer(recipient, unclaimedDai);
+            }
+        } else {
+            _withdrawPrincipal(id_, amount_);
+            IERC20(gOHM).safeTransfer(msg.sender, amount_);
+        }
+
+        emit Withdrawn(msg.sender, amount_);
+    }
+
+    /**
+        @notice Withdraw excess yield from your deposit in gOHM.
+        @dev  Use withdrawYieldAsDai() to withdraw yield as DAI.
+        @param id_ Id of the deposit.
+    */
+    function withdrawYield(uint256 id_) external override {
+        if (withdrawDisabled) revert WithdrawDisabled();
+        if (depositInfo[id_].depositor != msg.sender && depositInfo[id_].recipient != msg.sender)
+            revert UnauthorisedAction();
+
+        upkeepInfo[id_].lastUpkeepTimestamp = block.timestamp;
+
+        uint256 yield = _redeemYield(id_);
+
+        IERC20(gOHM).safeTransfer(msg.sender, yield);
+    }
+
+    /**
+        @notice Withdraw excess yield from your deposit in DAI
+        @param id_ Id of the deposit
+    */
+    function withdrawYieldAsDai(uint256 id_) external override {
+        if (withdrawDisabled) revert WithdrawDisabled();
+        if (depositInfo[id_].depositor != msg.sender && depositInfo[id_].recipient != msg.sender)
+            revert UnauthorisedAction();
+
+        upkeepInfo[id_].lastUpkeepTimestamp = block.timestamp;
+
+        uint256 gOHMYield = _redeemYield(id_);
+        uint256 totalOhmToSwap = staking.unwrap(address(this), gOHMYield);
+        staking.unstake(address(this), totalOhmToSwap, false, false);
+
+        IERC20(OHM).approve(address(sushiRouter), totalOhmToSwap);
+        uint256[] memory calculatedAmounts = sushiRouter.getAmountsOut(totalOhmToSwap, sushiRouterPath);
+        uint256[] memory amounts = sushiRouter.swapExactTokensForTokens(
+            totalOhmToSwap,
+            (calculatedAmounts[1] * (1000 - maxSwapSlippagePercent)) / 1000,
+            sushiRouterPath,
+            msg.sender,
+            block.timestamp
+        );
+
+        uint256 daiToSend = upkeepInfo[id_].unclaimedDai + amounts[1];
+        upkeepInfo[id_].unclaimedDai = 0;
+        IERC20(DAI).safeTransfer(msg.sender, daiToSend);
+    }
+
+    /**
+        @notice harvest all your unclaimed Dai
+        @param id_ Id of the deposit
+    */
+    function harvestDai(uint256 id_) external override {
+        if (withdrawDisabled) revert WithdrawDisabled();
+        if (depositInfo[id_].depositor != msg.sender && depositInfo[id_].recipient != msg.sender)
+            revert UnauthorisedAction();
+
+        uint256 daiToSend = upkeepInfo[id_].unclaimedDai;
+        upkeepInfo[id_].unclaimedDai = 0;
+        IERC20(DAI).safeTransfer(msg.sender, daiToSend);
+    }
+
+    /**
+        @notice User updates the minimum amount of DAI threshold before upkeep sends DAI to recipients wallet
+        @param id_ Id of the deposit
+        @param threshold_ amount of DAI
+    */
+    function updateUserMinDaiThreshold(uint256 id_, uint256 threshold_) external override {
+        if (threshold_ < minimumDaiThreshold) revert MinDaiThresholdTooLow();
+        if (depositInfo[id_].depositor != msg.sender) revert UnauthorisedAction();
+
+        upkeepInfo[id_].userMinimumDaiThreshold = threshold_;
+    }
+
+    /**
+        @notice User updates the minimum amount of time passes before the deposit is included in upkeep
+        @param id_ Id of the deposit
+        @param paymentInterval_ amount of time in seconds
+    */
+    function updatePaymentInterval(uint256 id_, uint256 paymentInterval_) external override {
+        if (depositInfo[id_].depositor != msg.sender) revert UnauthorisedAction();
+
+        upkeepInfo[id_].paymentInterval = paymentInterval_;
+    }
+
+    /**
+        @notice Upkeeps all deposits if they are eligible to be upkept. Converts excess yield from gOHM to DAI. Sends the yield to recipient wallets if above user set threshold.
+    */
+    function upkeep() external override {
+        if (upkeepDisabled) revert UpkeepDisabled();
+
+        uint256 totalGOHM;
+
+        for (uint256 i = 0; i < activeDepositIds.length; i++) {
+            uint256 currentId = activeDepositIds[i];
+
+            if (_isUpkeepEligible(currentId)) {
+                totalGOHM += getOutstandingYield(currentId);
+            }
+        }
+
+        uint256 feeToDao = (totalGOHM * feeToDaoPercent) / 1000;
+        IERC20(gOHM).safeTransfer(authority.governor(), feeToDao);
+
+        IERC20(gOHM).approve(address(staking), totalGOHM);
+        uint256 totalOhmToSwap = staking.unwrap(address(this), totalGOHM - feeToDao);
+        staking.unstake(address(this), totalOhmToSwap, false, false);
+
+        IERC20(OHM).approve(address(sushiRouter), totalOhmToSwap);
+        uint256[] memory calculatedAmounts = sushiRouter.getAmountsOut(totalOhmToSwap, sushiRouterPath);
+        uint256[] memory amounts = sushiRouter.swapExactTokensForTokens(
+            totalOhmToSwap,
+            (calculatedAmounts[1] * (1000 - maxSwapSlippagePercent)) / 1000,
+            sushiRouterPath,
+            address(this),
+            block.timestamp
+        );
+
+        for (uint256 i = 0; i < activeDepositIds.length; i++) {
+            // TODO: Is there a more gas efficient way than looping through this again and checking same condition
+            uint256 currentId = activeDepositIds[i];
+
+            if (_isUpkeepEligible(currentId)) {
+                UpkeepInfo storage currentUpkeepInfo = upkeepInfo[currentId];
+
+                currentUpkeepInfo.lastUpkeepTimestamp = block.timestamp;
+                currentUpkeepInfo.unclaimedDai += (amounts[1] * _redeemYield(currentId)) / totalGOHM;
+
+                if (currentUpkeepInfo.unclaimedDai >= currentUpkeepInfo.userMinimumDaiThreshold) {
+                    uint256 daiToSend = currentUpkeepInfo.unclaimedDai;
+                    currentUpkeepInfo.unclaimedDai = 0;
+                    IERC20(DAI).safeTransfer(depositInfo[currentId].recipient, daiToSend);
+                }
+            }
+        }
+
+        emit UpkeepComplete(block.timestamp);
+    }
+
+    /************************
+     * View Functions
+     ************************/
+
+    /**
+        @notice Returns the total amount of yield in gOhm the user can withdraw from all deposits. 
+                Does not include harvestable Dai which is found in upkeepInfo.
+        @param recipient_ Address of recipient.
+    */
+    function getTotalHarvestableYieldGOHM(address recipient_) external view returns (uint256 totalGOHM) {
+        for (uint256 i = 0; i < recipientIds[recipient_].length; i++) {
+            totalGOHM += getOutstandingYield(recipientIds[recipient_][i]);
+        }
+    }
+
+    /**
+        @notice Gets the number of deposits eligible for upkeep and amount of ohm of yield available to swap.
+        @return numberOfDepositsEligible : number of deposits eligible for upkeep.
+        @return amountOfYieldToSwap : total amount of yield in gOHM ready to be swapped in next upkeep.
+     */
+    function upkeepEligibility() external view returns (uint256 numberOfDepositsEligible, uint256 amountOfYieldToSwap) {
+        for (uint256 i = 0; i < activeDepositIds.length; i++) {
+            if (_isUpkeepEligible(activeDepositIds[i])) {
+                numberOfDepositsEligible++;
+                amountOfYieldToSwap += getOutstandingYield(activeDepositIds[i]);
+            }
+        }
+    }
+
+    /**
+        @notice Returns the outstanding yield of a deposit.
+        @param id_ Id of the deposit.
+     */
+    function getOutstandingYield(uint256 id_) public view returns (uint256) {
+        return _getOutstandingYield(depositInfo[id_].principalAmount, depositInfo[id_].agnosticAmount);
+    }
+
+    /**
+        @notice Get deposits principal amount in gOhm
+        @param id_ Id of the deposit.
+     */
+    function getPrincipalInGOHM(uint256 id_) external view returns (uint256) {
+        return IgOHM(gOHM).balanceTo(depositInfo[id_].principalAmount);
+    }
+
+    /**
+        @notice Returns whether deposit id is eligible for upkeep
+        @return bool
+     */
+    function _isUpkeepEligible(uint256 id_) internal view returns (bool) {
+        if (block.timestamp >= upkeepInfo[id_].lastUpkeepTimestamp + upkeepInfo[id_].paymentInterval) {
+            return true;
+        }
+        return false;
+    }
+
+    /************************
+     * Restricted Setter Functions
+     ************************/
+
+    /**
+        @notice Setter for maxSwapSlippagePercent.
+        @param slippagePercent_ new slippage value as a fraction / 1000.
+    */
+    function setMaxSwapSlippagePercent(uint256 slippagePercent_) external onlyGovernor {
+        maxSwapSlippagePercent = slippagePercent_;
+    }
+
+    /**
+        @notice Setter for feeToDaoPercent.
+        @param feePercent_ new fee value as a fraction / 1000.
+    */
+    function setFeeToDaoPercent(uint256 feePercent_) external onlyGovernor {
+        feeToDaoPercent = feePercent_;
+    }
+
+    /**
+        @notice Setter for minimumDaiThreshold.
+        @param minDaiThreshold_ new minimumDaiThreshold value.
+    */
+    function setMinimumDaiThreshold(uint256 minDaiThreshold_) external onlyGovernor {
+        minimumDaiThreshold = minDaiThreshold_;
+    }
+
+    /************************
+     * Emergency Functions
+     ************************/
+
+    function emergencyShutdown(bool active_) external onlyGovernor {
+        depositDisabled = active_;
+        withdrawDisabled = active_;
+        upkeepDisabled = active_;
+        emit EmergencyShutdown(active_);
+    }
+
+    function disableDeposits(bool active_) external onlyGovernor {
+        depositDisabled = active_;
+    }
+
+    function disableWithdrawals(bool active_) external onlyGovernor {
+        withdrawDisabled = active_;
+    }
+
+    function disableUpkeep(bool active_) external onlyGovernor {
+        upkeepDisabled = active_;
+    }
+}

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -142,9 +142,8 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
     */
     function addToDeposit(uint256 id_, uint256 amount_) external override {
         if (depositDisabled) revert YieldStreamer_DepositDisabled();
-        if (depositInfo[id_].depositor != msg.sender) revert YieldStreamer_UnauthorisedAction();
 
-        _addToDeposit(id_, amount_);
+        _addToDeposit(id_, amount_, msg.sender);
 
         IERC20(gOHM).safeTransferFrom(msg.sender, address(this), amount_);
 
@@ -164,7 +163,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         if (amount_ >= IgOHM(gOHM).balanceTo(depositInfo[id_].principalAmount)) {
             address recipient = recipientInfo[id_].recipientAddress;
             uint256 unclaimedStreamTokens = recipientInfo[id_].unclaimedStreamTokens;
-            (uint256 principal, uint256 totalGOHM) = _closeDeposit(id_);
+            (uint256 principal, uint256 totalGOHM) = _closeDeposit(id_, msg.sender);
             delete recipientInfo[id_];
 
             for (uint256 i = 0; i < activeDepositIds.length; i++) {
@@ -192,7 +191,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
                 IERC20(streamToken).safeTransfer(recipient, unclaimedStreamTokens);
             }
         } else {
-            _withdrawPrincipal(id_, amount_);
+            _withdrawPrincipal(id_, amount_, msg.sender);
             IERC20(gOHM).safeTransfer(msg.sender, amount_);
         }
 

--- a/test/tyche/YieldSplitter.test.ts
+++ b/test/tyche/YieldSplitter.test.ts
@@ -1,0 +1,295 @@
+import { ContractFactory } from "ethers";
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import {
+    OlympusStaking,
+    OlympusERC20Token,
+    GOHM,
+    OlympusAuthority,
+    DAI,
+    SOlympus,
+    OlympusTreasury,
+    Distributor,
+    YieldSplitterImpl,
+} from "../../types";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { toDecimals, toOhm, advanceEpoch } from "../utils/Utilities";
+
+describe("YieldSplitter", async () => {
+    const LARGE_APPROVAL = "100000000000000000000000000000000";
+    const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+    // Initial mint for Frax and DAI (10,000,000)
+    const initialMint = toDecimals(10000000);
+    // Reward rate of .1%
+    const initialRewardRate = "1000";
+
+    const triggerRebase = async () => {
+        advanceEpoch(); // 8 hours per rebase
+        await staking.rebase();
+        return await sOhm.index();
+    };
+
+    let deployer: SignerWithAddress;
+    let alice: SignerWithAddress;
+    let bob: SignerWithAddress;
+    let erc20Factory: ContractFactory;
+    let stakingFactory: ContractFactory;
+    let ohmFactory: ContractFactory;
+    let sOhmFactory: ContractFactory;
+    let gOhmFactory: ContractFactory;
+    let treasuryFactory: ContractFactory;
+    let distributorFactory: ContractFactory;
+    let authFactory: ContractFactory;
+    let yieldSplitterFactory: ContractFactory;
+
+    let auth: OlympusAuthority;
+    let dai: DAI;
+    let ohm: OlympusERC20Token;
+    let sOhm: SOlympus;
+    let staking: OlympusStaking;
+    let gOhm: GOHM;
+    let treasury: OlympusTreasury;
+    let distributor: Distributor;
+    let yieldSplitter: YieldSplitterImpl;
+
+    before(async () => {
+        [deployer, alice, bob] = await ethers.getSigners();
+        authFactory = await ethers.getContractFactory("OlympusAuthority");
+        erc20Factory = await ethers.getContractFactory("DAI");
+        stakingFactory = await ethers.getContractFactory("OlympusStaking");
+        ohmFactory = await ethers.getContractFactory("OlympusERC20Token");
+        sOhmFactory = await ethers.getContractFactory("sOlympus");
+        gOhmFactory = await ethers.getContractFactory("gOHM");
+        treasuryFactory = await ethers.getContractFactory("OlympusTreasury");
+        distributorFactory = await ethers.getContractFactory("Distributor");
+        yieldSplitterFactory = await ethers.getContractFactory("YieldSplitterImpl");
+    });
+
+    beforeEach(async () => {
+        dai = (await erc20Factory.deploy(0)) as DAI;
+        auth = (await authFactory.deploy(
+            deployer.address,
+            deployer.address,
+            deployer.address,
+            deployer.address
+        )) as OlympusAuthority;
+        ohm = (await ohmFactory.deploy(auth.address)) as OlympusERC20Token;
+        sOhm = (await sOhmFactory.deploy()) as SOlympus;
+        gOhm = (await gOhmFactory.deploy(deployer.address, sOhm.address)) as GOHM;
+        const blockNumBefore = await ethers.provider.getBlockNumber();
+        const blockBefore = await ethers.provider.getBlock(blockNumBefore);
+        staking = (await stakingFactory.deploy(
+            ohm.address,
+            sOhm.address,
+            gOhm.address,
+            "28800", // 1 epoch = 8 hours
+            "1",
+            blockBefore.timestamp + 28800, // First epoch in 8 hours. Avoids first deposit to set epoch.distribute wrong
+            auth.address
+        )) as OlympusStaking;
+        await gOhm.migrate(staking.address, sOhm.address);
+        treasury = (await treasuryFactory.deploy(
+            ohm.address,
+            "0",
+            auth.address
+        )) as OlympusTreasury;
+        distributor = (await distributorFactory.deploy(
+            treasury.address,
+            ohm.address,
+            staking.address,
+            auth.address
+        )) as Distributor;
+        yieldSplitter = (await yieldSplitterFactory.deploy(gOhm.address)) as YieldSplitterImpl;
+
+        // Setup for each component
+
+        // Needed for treasury deposit
+        await dai.mint(deployer.address, initialMint);
+        await dai.approve(treasury.address, LARGE_APPROVAL);
+
+        // Needed to spend deployer's OHM
+        await ohm.approve(staking.address, LARGE_APPROVAL);
+
+        // To get past OHM contract guards
+        await auth.pushVault(treasury.address, true);
+
+        // Initialization for sOHM contract.
+        // Set index to 10
+        await sOhm.setIndex("10000000000");
+        await sOhm.setgOHM(gOhm.address);
+        await sOhm.initialize(staking.address, treasury.address);
+
+        // Set distributor staking contract
+        await staking.setDistributor(distributor.address);
+
+        // queue and toggle reward manager
+        await treasury.enable("8", distributor.address, ZERO_ADDRESS);
+        // queue and toggle deployer reserve depositor
+        await treasury.enable("0", deployer.address, ZERO_ADDRESS);
+        // queue and toggle liquidity depositor
+        await treasury.enable("4", deployer.address, ZERO_ADDRESS);
+        // queue and toggle DAI as reserve token
+        await treasury.enable("2", dai.address, ZERO_ADDRESS);
+
+        // Deposit 10,000 DAI to treasury, 1,000 OHM gets minted to deployer with 9000 as excess reserves (ready to be minted)
+        await treasury.connect(deployer).deposit(toDecimals(10000), dai.address, toOhm(9000));
+
+        // Add staking as recipient of distributor with a test reward rate
+        await distributor.addRecipient(staking.address, initialRewardRate);
+
+        // Get sOHM in deployer wallet
+        const sohmAmount = toOhm(1000);
+        await ohm.approve(staking.address, sohmAmount);
+        await staking.stake(deployer.address, sohmAmount, true, true);
+        await triggerRebase(); // Trigger first rebase to set initial distribute amount. This rebase shouldn't update index.
+
+        // Transfer 100 sOHM to alice for testing
+        await sOhm.transfer(alice.address, toOhm(100));
+
+        // Alice should wrap ohm to gOhm. Should have 10gOhm
+        await sOhm.approve(staking.address, LARGE_APPROVAL);
+        await staking.wrap(deployer.address, toOhm(500));
+        await sOhm.connect(alice).approve(staking.address, LARGE_APPROVAL);
+        await staking.connect(alice).wrap(alice.address, toOhm(100));
+
+        await gOhm.connect(alice).approve(yieldSplitter.address, LARGE_APPROVAL);
+    });
+
+    it("should rebase properly", async () => {
+        await expect(await sOhm.index()).is.equal("10000000000");
+        await triggerRebase();
+        await expect(await sOhm.index()).is.equal("10010000000");
+        await triggerRebase();
+        await expect(await sOhm.index()).is.equal("10020010000");
+        await triggerRebase();
+        await expect(await sOhm.index()).is.equal("10030030010");
+    });
+
+    it("creating multiple deposits should update depositors and recipients arrays", async () => {
+        await yieldSplitter.deposit(deployer.address, alice.address, toDecimals(10));
+        await yieldSplitter.deposit(deployer.address, bob.address, toDecimals(10));
+        await yieldSplitter.deposit(alice.address, alice.address, toDecimals(5));
+        await yieldSplitter.deposit(alice.address, bob.address, toDecimals(5));
+
+        await expect(await yieldSplitter.idCount()).is.equal("4");
+        await expect(await yieldSplitter.depositorIds(deployer.address, 0)).is.equal("0");
+        await expect(await yieldSplitter.depositorIds(deployer.address, 1)).is.equal("1");
+        await expect(await yieldSplitter.depositorIds(alice.address, 0)).is.equal("2");
+        await expect(await yieldSplitter.depositorIds(alice.address, 1)).is.equal("3");
+        await expect(await yieldSplitter.recipientIds(alice.address, 0)).is.equal("0");
+        await expect(await yieldSplitter.recipientIds(alice.address, 1)).is.equal("2");
+        await expect(await yieldSplitter.recipientIds(bob.address, 0)).is.equal("1");
+        await expect(await yieldSplitter.recipientIds(bob.address, 1)).is.equal("3");
+        await expect((await yieldSplitter.depositInfo(0)).principalAmount).is.equal(toOhm(100));
+        await expect((await yieldSplitter.depositInfo(3)).principalAmount).is.equal(toOhm(50));
+    });
+
+    it("adding to deposit should calculate agostic with changing index", async () => {
+        await yieldSplitter.deposit(deployer.address, alice.address, toDecimals(10)); //10 gOhm, 100 sOhm
+        await triggerRebase();
+        await expect((await yieldSplitter.depositInfo(0)).principalAmount).is.equal(toOhm(100)); // still should be 100sOhm but less gOhm
+        await expect((await yieldSplitter.depositInfo(0)).agnosticAmount).is.equal(toDecimals(10)); // still should be 10gOhm. But its more than 100 sOhm
+        await yieldSplitter.addToDeposit(0, toDecimals(10)); // add another 10gOhm or 100.1 sOhm since index change
+        await expect((await yieldSplitter.depositInfo(0)).principalAmount).is.equal(toOhm(200.1)); // total sOhm should be 200.1
+        await expect((await yieldSplitter.depositInfo(0)).agnosticAmount).is.equal(toDecimals(20)); // agnostic should be 20 gOhm or 200.2 sOhm.
+        const expectedYield = await gOhm.balanceTo(toOhm(0.1)); // yield is 0.1sOhm convert this to gOhm
+        const actualYield = await yieldSplitter.getOutstandingYield(
+            (
+                await yieldSplitter.depositInfo(0)
+            ).principalAmount,
+            (
+                await yieldSplitter.depositInfo(0)
+            ).agnosticAmount
+        );
+        await expect(actualYield).is.closeTo(expectedYield, 1); // 1 digit off due to precision issues of converting gOhm to sOhm and back to gOhm.
+    });
+
+    it("withdrawing principal only reduces principal amount", async () => {
+        await yieldSplitter.deposit(deployer.address, alice.address, toDecimals(10)); //10 gOhm, 100 sOhm
+        await yieldSplitter.withdrawPrincipal(0, toDecimals(5));
+        const principalAfter = (await yieldSplitter.depositInfo(0)).principalAmount;
+        await expect(principalAfter).is.equal(toOhm(50)); // should be 50 sOhm
+    });
+
+    it("cannot withdraw more principal than there already is", async () => {
+        await yieldSplitter.deposit(deployer.address, alice.address, toDecimals(10)); //10 gOhm, 100 sOhm
+        await expect(yieldSplitter.withdrawPrincipal(0, toDecimals(100))).to.be.reverted;
+    });
+
+    it("closing a deposit deletes the item from mapping and depositor and recipient id arrays", async () => {
+        await yieldSplitter.deposit(deployer.address, alice.address, toDecimals(10));
+        await expect(await yieldSplitter.depositorIds(deployer.address, 0)).is.equal("0");
+        await expect(await yieldSplitter.recipientIds(alice.address, 0)).is.equal("0");
+        await yieldSplitter.closeDeposit(0);
+        await expect(yieldSplitter.depositorIds(deployer.address, 0)).to.be.reverted;
+    });
+
+    it("redeeming yield makes getOutstandingYield return 0", async () => {
+        await yieldSplitter.deposit(deployer.address, alice.address, toDecimals(10));
+        await triggerRebase();
+        const yieldBefore = await yieldSplitter.getOutstandingYield(
+            (
+                await yieldSplitter.depositInfo(0)
+            ).principalAmount,
+            (
+                await yieldSplitter.depositInfo(0)
+            ).agnosticAmount
+        );
+        await expect(yieldBefore).to.equal("9990009990009991");
+        await yieldSplitter.redeemYield(0);
+        const yieldAfter = await yieldSplitter.getOutstandingYield(
+            (
+                await yieldSplitter.depositInfo(0)
+            ).principalAmount,
+            (
+                await yieldSplitter.depositInfo(0)
+            ).agnosticAmount
+        );
+        await expect(yieldAfter).to.equal(0);
+    });
+
+    it("redeem all redeems yield from all your deposits you are recipient of", async () => {
+        await yieldSplitter.deposit(deployer.address, alice.address, toDecimals(10));
+        await yieldSplitter.deposit(alice.address, alice.address, toDecimals(10));
+        await yieldSplitter.redeemAllYield(alice.address);
+        const yieldZero = await yieldSplitter.getOutstandingYield(
+            (
+                await yieldSplitter.depositInfo(0)
+            ).principalAmount,
+            (
+                await yieldSplitter.depositInfo(0)
+            ).agnosticAmount
+        );
+        const yieldOne = await yieldSplitter.getOutstandingYield(
+            (
+                await yieldSplitter.depositInfo(1)
+            ).principalAmount,
+            (
+                await yieldSplitter.depositInfo(1)
+            ).agnosticAmount
+        );
+        await expect(yieldZero).to.equal(0);
+        await expect(yieldOne).to.equal(0);
+    });
+
+    it("precision issue with gOHM conversion should not allow users to withdraw more than they have", async () => {
+        await gOhm.connect(deployer).transfer(bob.address, toDecimals(10));
+        await yieldSplitter.deposit(bob.address, bob.address, toDecimals(10));
+        await triggerRebase();
+
+        let harvestedYield = await yieldSplitter.getOutstandingYield(
+            (
+                await yieldSplitter.depositInfo(0)
+            ).principalAmount,
+            (
+                await yieldSplitter.depositInfo(0)
+            ).agnosticAmount
+        );
+        await gOhm.connect(bob).transfer(deployer.address, harvestedYield);
+
+        let principal = (await yieldSplitter.depositInfo(0)).principalAmount;
+        let principalInGOHM = await gOhm.balanceTo(principal);
+        await gOhm.connect(bob).transfer(deployer.address, principalInGOHM);
+        await expect(await gOhm.balanceOf(bob.address)).is.equal(0);
+    });
+});

--- a/test/tyche/YieldStreamer.test.ts
+++ b/test/tyche/YieldStreamer.test.ts
@@ -113,8 +113,8 @@ describe("YieldStreamer", async () => {
             sushiRouter.address,
             staking.address,
             auth.address,
-            1,
-            1,
+            1000,
+            1000,
             toDecimals(1)
         )) as YieldStreamer;
 
@@ -312,8 +312,8 @@ describe("YieldStreamer", async () => {
     });
 
     it("Governor can update contract settins", async () => {
-        await expect(await yieldStreamer.maxSwapSlippagePercent()).is.equal(1);
-        await expect(await yieldStreamer.feeToDaoPercent()).is.equal(1);
+        await expect(await yieldStreamer.maxSwapSlippagePercent()).is.equal(1000);
+        await expect(await yieldStreamer.feeToDaoPercent()).is.equal(1000);
         await expect(await yieldStreamer.minimumDaiThreshold()).is.equal(toDecimals(1));
 
         await yieldStreamer.setMaxSwapSlippagePercent(10);

--- a/test/tyche/YieldStreamer.test.ts
+++ b/test/tyche/YieldStreamer.test.ts
@@ -1,0 +1,358 @@
+import { BigNumber, ContractFactory } from "ethers";
+import { ethers } from "hardhat";
+import chai, { expect } from "chai";
+import {
+    OlympusStaking,
+    OlympusERC20Token,
+    GOHM,
+    OlympusAuthority,
+    DAI,
+    SOlympus,
+    OlympusTreasury,
+    Distributor,
+    YieldStreamer,
+    IUniswapV2Router,
+} from "../../types";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { toDecimals, toOhm, advanceEpoch, fromDecimals } from "../utils/Utilities";
+import { FakeContract, smock } from "@defi-wonderland/smock";
+
+describe.only("YieldStreamer", async () => {
+    const LARGE_APPROVAL = "100000000000000000000000000000000";
+    const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+    // Initial mint for Frax and DAI (10,000,000)
+    const initialMint = toDecimals(10000000);
+    // Reward rate of .1%
+    const initialRewardRate = "1000";
+
+    const triggerRebase = async () => {
+        advanceEpoch(); // 8 hours per rebase
+        await staking.rebase();
+        return await sOhm.index();
+    };
+
+    chai.use(smock.matchers);
+
+    let deployer: SignerWithAddress;
+    let alice: SignerWithAddress;
+    let bob: SignerWithAddress;
+    let erc20Factory: ContractFactory;
+    let stakingFactory: ContractFactory;
+    let ohmFactory: ContractFactory;
+    let sOhmFactory: ContractFactory;
+    let gOhmFactory: ContractFactory;
+    let treasuryFactory: ContractFactory;
+    let distributorFactory: ContractFactory;
+    let authFactory: ContractFactory;
+    let yieldStreamerFactory: ContractFactory;
+
+    let auth: OlympusAuthority;
+    let dai: DAI;
+    let ohm: OlympusERC20Token;
+    let sOhm: SOlympus;
+    let staking: OlympusStaking;
+    let gOhm: GOHM;
+    let treasury: OlympusTreasury;
+    let distributor: Distributor;
+    let yieldStreamer: YieldStreamer;
+    let sushiRouter: FakeContract<IUniswapV2Router>;
+
+    before(async () => {
+        [deployer, alice, bob] = await ethers.getSigners();
+        authFactory = await ethers.getContractFactory("OlympusAuthority");
+        erc20Factory = await ethers.getContractFactory("DAI");
+        stakingFactory = await ethers.getContractFactory("OlympusStaking");
+        ohmFactory = await ethers.getContractFactory("OlympusERC20Token");
+        sOhmFactory = await ethers.getContractFactory("sOlympus");
+        gOhmFactory = await ethers.getContractFactory("gOHM");
+        treasuryFactory = await ethers.getContractFactory("OlympusTreasury");
+        distributorFactory = await ethers.getContractFactory("Distributor");
+        yieldStreamerFactory = await ethers.getContractFactory("YieldStreamer");
+        sushiRouter = await smock.fake<IUniswapV2Router>("IUniswapV2Router");
+    });
+
+    beforeEach(async () => {
+        dai = (await erc20Factory.deploy(0)) as DAI;
+        auth = (await authFactory.deploy(
+            deployer.address,
+            deployer.address,
+            deployer.address,
+            deployer.address
+        )) as OlympusAuthority;
+        ohm = (await ohmFactory.deploy(auth.address)) as OlympusERC20Token;
+        sOhm = (await sOhmFactory.deploy()) as SOlympus;
+        gOhm = (await gOhmFactory.deploy(deployer.address, sOhm.address)) as GOHM;
+        const blockNumBefore = await ethers.provider.getBlockNumber();
+        const blockBefore = await ethers.provider.getBlock(blockNumBefore);
+        staking = (await stakingFactory.deploy(
+            ohm.address,
+            sOhm.address,
+            gOhm.address,
+            "28800", // 1 epoch = 8 hours
+            "1",
+            blockBefore.timestamp + 28800, // First epoch in 8 hours. Avoids first deposit to set epoch.distribute wrong
+            auth.address
+        )) as OlympusStaking;
+        await gOhm.migrate(staking.address, sOhm.address);
+        treasury = (await treasuryFactory.deploy(
+            ohm.address,
+            "0",
+            auth.address
+        )) as OlympusTreasury;
+        distributor = (await distributorFactory.deploy(
+            treasury.address,
+            ohm.address,
+            staking.address,
+            auth.address
+        )) as Distributor;
+        yieldStreamer = (await yieldStreamerFactory.deploy(
+            gOhm.address,
+            ohm.address,
+            dai.address,
+            sushiRouter.address,
+            staking.address,
+            auth.address,
+            1,
+            1,
+            toDecimals(1)
+        )) as YieldStreamer;
+
+        // Setup for each component
+
+        // Needed for treasury deposit
+        await dai.mint(deployer.address, initialMint);
+        await dai.approve(treasury.address, LARGE_APPROVAL);
+
+        // Needed to spend deployer's OHM
+        await ohm.approve(staking.address, LARGE_APPROVAL);
+
+        // To get past OHM contract guards
+        await auth.pushVault(treasury.address, true);
+
+        // Initialization for sOHM contract.
+        // Set index to 10
+        await sOhm.setIndex("10000000000");
+        await sOhm.setgOHM(gOhm.address);
+        await sOhm.initialize(staking.address, treasury.address);
+
+        // Set distributor staking contract
+        await staking.setDistributor(distributor.address);
+
+        // queue and toggle reward manager
+        await treasury.enable("8", distributor.address, ZERO_ADDRESS);
+        // queue and toggle deployer reserve depositor
+        await treasury.enable("0", deployer.address, ZERO_ADDRESS);
+        // queue and toggle liquidity depositor
+        await treasury.enable("4", deployer.address, ZERO_ADDRESS);
+        // queue and toggle DAI as reserve token
+        await treasury.enable("2", dai.address, ZERO_ADDRESS);
+
+        // Deposit 10,000 DAI to treasury, 1,000 OHM gets minted to deployer with 9000 as excess reserves (ready to be minted)
+        await treasury.connect(deployer).deposit(toDecimals(10000), dai.address, toOhm(9000));
+
+        // Add staking as recipient of distributor with a test reward rate
+        await distributor.addRecipient(staking.address, initialRewardRate);
+
+        // Get sOHM in deployer wallet
+        const sohmAmount = toOhm(1000);
+        await ohm.approve(staking.address, sohmAmount);
+        await staking.stake(deployer.address, sohmAmount, true, true);
+        await triggerRebase(); // Trigger first rebase to set initial distribute amount. This rebase shouldn't update index.
+
+        // Transfer 100 sOHM to alice for testing
+        await sOhm.transfer(alice.address, toOhm(100));
+
+        // Alice should wrap ohm to gOhm. Should have 10gOhm
+        await sOhm.approve(staking.address, LARGE_APPROVAL);
+        await staking.wrap(deployer.address, toOhm(500));
+        await sOhm.connect(alice).approve(staking.address, LARGE_APPROVAL);
+        await staking.connect(alice).wrap(alice.address, toOhm(100));
+
+        await gOhm.connect(alice).approve(yieldStreamer.address, LARGE_APPROVAL);
+        await gOhm.connect(deployer).approve(yieldStreamer.address, LARGE_APPROVAL);
+        await dai.connect(deployer).transfer(yieldStreamer.address, toDecimals(1000000)); // Give dai to yieldstreamer so it has dai to pay out. Mocking the ohm dai swap with smock.
+    });
+
+    it("should rebase properly", async () => {
+        await expect(await sOhm.index()).is.equal("10000000000");
+        await triggerRebase();
+        await expect(await sOhm.index()).is.equal("10010000000");
+        await triggerRebase();
+        await expect(await sOhm.index()).is.equal("10020010000");
+        await triggerRebase();
+        await expect(await sOhm.index()).is.equal("10030030010");
+    });
+
+    it("Upkeep sends correct amount of dai to recipients. Deposit and Upkeep info updated correctly.", async () => {
+        await yieldStreamer
+            .connect(deployer)
+            .deposit(toDecimals(10), bob.address, 1, toDecimals(5));
+        await expect(
+            await yieldStreamer
+                .connect(alice)
+                .deposit(toDecimals(10), alice.address, 1, toDecimals(5))
+        ).to.emit(yieldStreamer, "Deposited");
+
+        await expect(await yieldStreamer.idCount()).is.equal("2");
+        await expect((await yieldStreamer.depositInfo(0)).principalAmount).is.equal(toOhm(100));
+        await expect((await yieldStreamer.upkeepInfo(0)).paymentInterval).is.equal(1);
+        await expect((await yieldStreamer.upkeepInfo(0)).userMinimumDaiThreshold).is.equal(
+            toDecimals(5)
+        );
+        await expect(await yieldStreamer.activeDepositIds(1)).is.equal(1);
+
+        await triggerRebase();
+
+        const expectedYield = await gOhm.balanceTo(toOhm(0.1)); // yield is 0.1sOhm convert this to gOhm
+        const actualYield = await yieldStreamer.getOutstandingYield(0);
+        await expect(actualYield).is.closeTo(expectedYield, 1); // 1 digit off due to precision issues of converting gOhm to sOhm and back to gOhm.
+
+        const amountOfDai = toOhm(0.2).mul(100).mul(1000000000).mul(999).div(1000); // Mock the amount of Dai coming out of swap.
+        sushiRouter.getAmountsOut.returns([BigNumber.from("0"), amountOfDai]);
+        sushiRouter.swapExactTokensForTokens.returns([BigNumber.from("0"), amountOfDai]);
+
+        await yieldStreamer.upkeep();
+
+        await expect(await dai.balanceOf(bob.address)).is.equal(amountOfDai.div(2));
+        await expect(await dai.balanceOf(alice.address)).is.equal(amountOfDai.div(2));
+    });
+
+    it("Adding to deposit calculates agnostic with changing index. Withdrawing does not withdraw more gOhm than there is.", async () => {
+        await yieldStreamer.connect(alice).deposit(toDecimals(5), alice.address, 1, toDecimals(5)); //5 gOhm deposited, 50 sOhm principal
+        await triggerRebase();
+
+        await expect((await yieldStreamer.depositInfo(0)).principalAmount).is.equal(toOhm(50)); // still should be 100sOhm but less gOhm
+        await expect((await yieldStreamer.depositInfo(0)).agnosticAmount).is.equal(toDecimals(5)); // still should be 10gOhm. But its more than 100 sOhm
+
+        await yieldStreamer.connect(alice).addToDeposit(0, toDecimals(5)); // add another 5gOhm or 50.05 sOhm since index change
+        await expect((await yieldStreamer.depositInfo(0)).principalAmount).is.equal(toOhm(100.05)); // total sOhm should be 100.05
+        await expect((await yieldStreamer.depositInfo(0)).agnosticAmount).is.equal(toDecimals(10)); // agnostic should be 20 gOhm or 200.2 sOhm.
+
+        const expectedYield = await gOhm.balanceTo(toOhm(0.05)); // yield is 0.05sOhm convert this to gOhm
+        const actualYield = await yieldStreamer.getOutstandingYield(0);
+        await expect(actualYield).is.closeTo(expectedYield, 1); // 1 digit off due to precision issues of converting gOhm to sOhm and back to gOhm.
+
+        await yieldStreamer.connect(alice).withdrawYield(0);
+        await expect(await gOhm.balanceOf(alice.address)).is.equal(actualYield);
+
+        let principalInGOHM = await yieldStreamer.getPrincipalInGOHM(0);
+        await yieldStreamer.connect(alice).withdrawPrincipal(0, toDecimals(10));
+        await expect(await gOhm.balanceOf(alice.address)).is.equal(
+            principalInGOHM.add(actualYield)
+        );
+    });
+
+    it("withdrawing part of principal", async () => {
+        await yieldStreamer.connect(alice).deposit(toDecimals(10), alice.address, 1, toDecimals(5)); //10gOhm deposited. 100sOhm principal
+        await triggerRebase();
+        await expect(await gOhm.balanceOf(alice.address)).is.equal("0");
+
+        await expect(
+            await yieldStreamer.connect(alice).withdrawPrincipal(0, toDecimals(5))
+        ).to.emit(yieldStreamer, "Withdrawn"); // withdraw 5 gOhm principal should be a bit less than 100sOhm since rebase happened
+        await expect(await gOhm.balanceOf(alice.address)).is.equal(toDecimals(5));
+        await expect((await yieldStreamer.depositInfo(0)).principalAmount).is.equal(toOhm(49.95));
+    });
+
+    it("harvest unclaimed dai premature", async () => {
+        await yieldStreamer
+            .connect(alice)
+            .deposit(toDecimals(10), alice.address, 1, toDecimals(1000));
+        await triggerRebase();
+
+        const actualYield = await yieldStreamer.getOutstandingYield(0); // yield is around 0.1sOhm convert this to gOhm
+        const amountOfDai = toOhm(0.1).mul(100).mul(1000000000); // Mock the amount of Dai coming out of swap. 0.1 Ohm should give roughly 10 DAi. Assuming Ohm=100DAI
+        sushiRouter.getAmountsOut.returns([BigNumber.from("0"), amountOfDai]);
+        sushiRouter.swapExactTokensForTokens.returns([BigNumber.from("0"), amountOfDai]);
+
+        await expect(await yieldStreamer.upkeep()).to.emit(yieldStreamer, "UpkeepComplete");
+
+        await expect((await yieldStreamer.upkeepInfo(0)).unclaimedDai).is.equals(toDecimals(10));
+        await yieldStreamer.connect(alice).harvestDai(0);
+        await expect(await dai.balanceOf(alice.address)).is.equals(toDecimals(10));
+    });
+
+    it("Disabled functions revert", async () => {
+        await yieldStreamer.disableDeposits(true);
+        await expect(
+            yieldStreamer.deposit(toDecimals(5), alice.address, 1, toDecimals(5))
+        ).to.be.revertedWith("DepositDisabled");
+        await expect(yieldStreamer.addToDeposit(0, toDecimals(5))).to.be.revertedWith(
+            "DepositDisabled"
+        );
+        await yieldStreamer.disableDeposits(false);
+        await yieldStreamer.connect(alice).deposit(toDecimals(10), alice.address, 1, toDecimals(5));
+
+        await triggerRebase();
+        await yieldStreamer.disableUpkeep(true);
+        await expect(yieldStreamer.upkeep()).to.be.revertedWith("UpkeepDisabled");
+
+        await yieldStreamer.disableWithdrawals(true);
+        await expect(yieldStreamer.withdrawPrincipal(0, toDecimals(10))).to.be.revertedWith(
+            "WithdrawDisabled"
+        );
+        await expect(yieldStreamer.withdrawYield(0)).to.be.revertedWith("WithdrawDisabled");
+        await expect(yieldStreamer.withdrawYieldAsDai(0)).to.be.revertedWith("WithdrawDisabled");
+        await expect(yieldStreamer.harvestDai(0)).to.be.revertedWith("WithdrawDisabled");
+    });
+
+    it("User can update user settings", async () => {
+        await yieldStreamer
+            .connect(alice)
+            .deposit(toDecimals(10), alice.address, 604800, toDecimals(1000));
+        await expect((await yieldStreamer.upkeepInfo(0)).paymentInterval).is.equal(604800);
+        await expect((await yieldStreamer.upkeepInfo(0)).userMinimumDaiThreshold).is.equal(
+            toDecimals(1000)
+        );
+
+        await yieldStreamer.connect(alice).updatePaymentInterval(0, 2419200);
+        await yieldStreamer.connect(alice).updateUserMinDaiThreshold(0, toDecimals(2000));
+
+        await expect((await yieldStreamer.upkeepInfo(0)).paymentInterval).is.equal(2419200);
+        await expect((await yieldStreamer.upkeepInfo(0)).userMinimumDaiThreshold).is.equal(
+            toDecimals(2000)
+        );
+    });
+
+    it("Governor can update contract settins", async () => {
+        await expect(await yieldStreamer.maxSwapSlippagePercent()).is.equal(1);
+        await expect(await yieldStreamer.feeToDaoPercent()).is.equal(1);
+        await expect(await yieldStreamer.minimumDaiThreshold()).is.equal(toDecimals(1));
+
+        await yieldStreamer.setMaxSwapSlippagePercent(10);
+        await yieldStreamer.setFeeToDaoPercent(10);
+        await yieldStreamer.setMinimumDaiThreshold(toDecimals(1000));
+
+        await expect(await yieldStreamer.maxSwapSlippagePercent()).is.equal(10);
+        await expect(await yieldStreamer.feeToDaoPercent()).is.equal(10);
+        await expect(await yieldStreamer.minimumDaiThreshold()).is.equal(toDecimals(1000));
+    });
+
+    it("Upkeep Eligibility returns correct values", async () => {
+        await yieldStreamer
+            .connect(deployer)
+            .deposit(toDecimals(10), bob.address, 1, toDecimals(5));
+        await yieldStreamer.connect(alice).deposit(toDecimals(10), alice.address, 1, toDecimals(5));
+
+        await triggerRebase();
+
+        let yieldPerDeposit = await yieldStreamer.getOutstandingYield(0);
+        let upkeepEligibility = await yieldStreamer.upkeepEligibility();
+        await expect(upkeepEligibility[0]).is.equals("2");
+        await expect(upkeepEligibility[1]).is.equals(yieldPerDeposit.mul(2));
+    });
+
+    it("Returns recipients total yield with multiple deposits", async () => {
+        await yieldStreamer
+            .connect(deployer)
+            .deposit(toDecimals(10), bob.address, 1, toDecimals(5));
+        await yieldStreamer.connect(alice).deposit(toDecimals(10), bob.address, 1, toDecimals(5));
+
+        await triggerRebase();
+
+        let yieldPerDeposit = await yieldStreamer.getOutstandingYield(0);
+        await expect(await yieldStreamer.getTotalHarvestableYieldGOHM(bob.address)).is.equals(
+            yieldPerDeposit.mul(2)
+        );
+    });
+});

--- a/test/tyche/YieldStreamer.test.ts
+++ b/test/tyche/YieldStreamer.test.ts
@@ -198,7 +198,7 @@ describe("YieldStreamer", async () => {
         await expect((await yieldStreamer.depositInfo(0)).principalAmount).is.equal(toOhm(100));
         await expect((await yieldStreamer.recipientInfo(0)).recipientAddress).is.equal(bob.address);
         await expect((await yieldStreamer.recipientInfo(0)).paymentInterval).is.equal(1);
-        await expect((await yieldStreamer.recipientInfo(0)).userMinimumDaiThreshold).is.equal(
+        await expect((await yieldStreamer.recipientInfo(0)).userMinimumAmountThreshold).is.equal(
             toDecimals(5)
         );
         await expect(await yieldStreamer.activeDepositIds(1)).is.equal(1);
@@ -268,8 +268,10 @@ describe("YieldStreamer", async () => {
 
         await expect(await yieldStreamer.upkeep()).to.emit(yieldStreamer, "UpkeepComplete");
 
-        await expect((await yieldStreamer.recipientInfo(0)).unclaimedDai).is.equals(toDecimals(10));
-        await yieldStreamer.connect(alice).harvestDai(0);
+        await expect((await yieldStreamer.recipientInfo(0)).unclaimedStreamTokens).is.equals(
+            toDecimals(10)
+        );
+        await yieldStreamer.connect(alice).harvestStreamTokens(0);
         await expect(await dai.balanceOf(alice.address)).is.equals(toDecimals(10));
     });
 
@@ -293,8 +295,10 @@ describe("YieldStreamer", async () => {
             "WithdrawDisabled"
         );
         await expect(yieldStreamer.withdrawYield(0)).to.be.revertedWith("WithdrawDisabled");
-        await expect(yieldStreamer.withdrawYieldAsDai(0)).to.be.revertedWith("WithdrawDisabled");
-        await expect(yieldStreamer.harvestDai(0)).to.be.revertedWith("WithdrawDisabled");
+        await expect(yieldStreamer.withdrawYieldInStreamTokens(0)).to.be.revertedWith(
+            "WithdrawDisabled"
+        );
+        await expect(yieldStreamer.harvestStreamTokens(0)).to.be.revertedWith("WithdrawDisabled");
     });
 
     it("User can update user settings", async () => {
@@ -306,7 +310,7 @@ describe("YieldStreamer", async () => {
         await yieldStreamer.connect(alice).updateUserMinDaiThreshold(0, toDecimals(2000));
 
         await expect((await yieldStreamer.recipientInfo(0)).paymentInterval).is.equal(2419200);
-        await expect((await yieldStreamer.recipientInfo(0)).userMinimumDaiThreshold).is.equal(
+        await expect((await yieldStreamer.recipientInfo(0)).userMinimumAmountThreshold).is.equal(
             toDecimals(2000)
         );
     });
@@ -314,15 +318,15 @@ describe("YieldStreamer", async () => {
     it("Governor can update contract settins", async () => {
         await expect(await yieldStreamer.maxSwapSlippagePercent()).is.equal(1000);
         await expect(await yieldStreamer.feeToDaoPercent()).is.equal(1000);
-        await expect(await yieldStreamer.minimumDaiThreshold()).is.equal(toDecimals(1));
+        await expect(await yieldStreamer.minimumTokenThreshold()).is.equal(toDecimals(1));
 
         await yieldStreamer.setMaxSwapSlippagePercent(10);
         await yieldStreamer.setFeeToDaoPercent(10);
-        await yieldStreamer.setMinimumDaiThreshold(toDecimals(1000));
+        await yieldStreamer.setminimumTokenThreshold(toDecimals(1000));
 
         await expect(await yieldStreamer.maxSwapSlippagePercent()).is.equal(10);
         await expect(await yieldStreamer.feeToDaoPercent()).is.equal(10);
-        await expect(await yieldStreamer.minimumDaiThreshold()).is.equal(toDecimals(1000));
+        await expect(await yieldStreamer.minimumTokenThreshold()).is.equal(toDecimals(1000));
     });
 
     it("Upkeep Eligibility returns correct values", async () => {

--- a/test/tyche/YieldStreamer.test.ts
+++ b/test/tyche/YieldStreamer.test.ts
@@ -244,6 +244,22 @@ describe("YieldStreamer", async () => {
         );
     });
 
+    it("withdrawing all yield does it for all deposits recipient is liable for", async () => {
+        await yieldStreamer
+            .connect(deployer)
+            .deposit(toDecimals(10), alice.address, 1, toDecimals(5));
+        await yieldStreamer.connect(alice).deposit(toDecimals(10), alice.address, 1, toDecimals(5));
+        await triggerRebase();
+        await expect(await gOhm.balanceOf(alice.address)).is.equal("0");
+
+        let expectedYield = await yieldStreamer.getOutstandingYield(0);
+
+        await yieldStreamer.connect(alice).withdrawAllYield();
+        await expect(await yieldStreamer.getOutstandingYield(0)).is.equal(0);
+        await expect(await yieldStreamer.getOutstandingYield(1)).is.equal(0);
+        await expect(await gOhm.balanceOf(alice.address)).is.equal(expectedYield.mul(2));
+    });
+
     it("withdrawing part of principal", async () => {
         await yieldStreamer.connect(alice).deposit(toDecimals(10), alice.address, 1, toDecimals(5)); //10gOhm deposited. 100sOhm principal
         await triggerRebase();

--- a/test/tyche/YieldStreamer.test.ts
+++ b/test/tyche/YieldStreamer.test.ts
@@ -17,7 +17,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { toDecimals, toOhm, advanceEpoch, fromDecimals } from "../utils/Utilities";
 import { FakeContract, smock } from "@defi-wonderland/smock";
 
-describe.only("YieldStreamer", async () => {
+describe("YieldStreamer", async () => {
     const LARGE_APPROVAL = "100000000000000000000000000000000";
     const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
     // Initial mint for Frax and DAI (10,000,000)

--- a/test/utils/Utilities.ts
+++ b/test/utils/Utilities.ts
@@ -1,0 +1,32 @@
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+
+// 18 decimals conversion
+export const fromDecimals = (bigNumber: BigNumber): number => {
+    return Number(ethers.utils.formatEther(bigNumber));
+};
+
+// 18 decimals conversion
+export const toDecimals = (amount: number): BigNumber => {
+    return ethers.utils.parseEther(amount.toString());
+};
+
+// 9 decimals conversion
+export const fromOhm = (bigNumber: BigNumber): number => {
+    return Number(ethers.utils.formatUnits(bigNumber, 9));
+};
+
+// 9 decimals conversion
+export const toOhm = (amount: number): BigNumber => {
+    return ethers.utils.parseUnits(amount.toString(), 9);
+};
+
+// 8 hours
+export const advanceEpoch = async (): Promise<void> => {
+    await advanceTime(8 * 60 * 60);
+};
+
+export const advanceTime = async (seconds: number): Promise<void> => {
+    await ethers.provider.send("evm_increaseTime", [seconds]);
+    await ethers.provider.send("evm_mine", []);
+};


### PR DESCRIPTION
Motivation:
It's been requested in the discord for a contract to allow users to deposit their ohm and allow the yield to be converted to DAI in whatever time interval they want. The goal of the contract is to automate that and socialise the gas costs. 

Another goal is to encapsulate the common logic between yieldstreamer and yielddirector to create a reusable component that handles the logic for splitting deposits into the principal and yield component.

Changes:
Created mvp of the contract for review to get some feedback. If no glaring problems will proceed with tests and possibly engage frontend since we have idea of what interface they will call looks like.

For the common logic of splitting deposits into principal and yield I have created an abstract contract that serves as a base layer for all contracts that require this knowledge. The abstract contract is built to be as general as possible so it is easy to build on top of and make customisations. The contract aims to only concern itself with the accounting of splitting gOHM from its principal to yield component.

User Flow:
Users deposit their gOHM into the contract. They set parameters like userMinimumDaiThreshold(Lowest amount of dai they willing to accumulate before its send to them) and paymentInterval(minimum time elapse before their ohm yields are swapped into dai).

The DAO runs a gelato job so every once in a while(week maybe) it upkeeps the contract. During an upkeep users whos payment Interval has passed will have their yield in OHM swapped to DAI. If the amount of DAI they have to claim passes a user set threshold they will have it sent to their address they put. The DAO will get a fee in gOHM every time the swap to DAI happens. This will essentially pay for the gas costs of up-keeping the contract.

Users also have the option to withdraw at any time or claim their yield at any time in gOhm or DAI.

Not Done:
Have no tested on testnet will do that after writing tests and looks good locally.