### PR TITLE
feat: Common yieldsplitter logic

### DIFF
--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.10;
+
+import {IERC20} from "../interfaces/IERC20.sol";
+import {IgOHM} from "../interfaces/IgOHM.sol";
+import {SafeERC20} from "../libraries/SafeERC20.sol";
+
+/**
+    @title YieldSplitter
+    @notice Abstract contract that allows users to create deposits for their gOHM and have
+            their yield claimable by the specified recipient party. This contract's functions
+            are designed to be as generic as possible. This contract's responsibility is
+            the accounting of the yield splitting. All other logic such as error handling,
+            emergency controls, sending and recieving gOHM is up to the implementation of
+            this abstract contract to handle.
+ */
+abstract contract YieldSplitter {
+    using SafeERC20 for IERC20;
+
+    address public immutable gOHM;
+
+    struct DepositInfo {
+        uint256 id;
+        address depositor;
+        uint256 principalAmount; // Total amount of sOhm deposited as principal, 9 decimals.
+        uint256 agnosticAmount; // Total amount deposited priced in gOhm. 18 decimals.
+    }
+
+    uint256 public idCount;
+    mapping(uint256 => DepositInfo) public depositInfo; // depositId -> DepositInfo
+    mapping(address => uint256[]) public depositorIds; // address -> Array of the deposit id's deposited by user
+
+    /**
+        @notice Constructor
+        @param gOHM_ Address of gOHM.
+    */
+    constructor(address gOHM_) {
+        gOHM = gOHM_;
+    }
+
+    /**
+        @notice Create a deposit.
+        @param depositor_ Address of depositor
+        @param amount_ Amount in gOhm. 18 decimals.
+    */
+    function _deposit(
+        address depositor_,
+        uint256 amount_
+    ) internal returns (uint256 depositId) {
+        depositorIds[depositor_].push(idCount);
+
+        depositInfo[idCount] = DepositInfo({
+            id: idCount,
+            depositor: depositor_,
+            principalAmount: IgOHM(gOHM).balanceFrom(amount_),
+            agnosticAmount: amount_
+        });
+
+        depositId = idCount;
+        idCount++;
+    }
+
+    /**
+        @notice Add more gOhm to the depositor's principal deposit.
+        @param id_ Id of the deposit.
+        @param amount_ Amount of gOhm to add. 18 decimals.
+    */
+    function _addToDeposit(uint256 id_, uint256 amount_) internal {
+        DepositInfo storage userDeposit = depositInfo[id_];
+        userDeposit.principalAmount += IgOHM(gOHM).balanceFrom(amount_);
+        userDeposit.agnosticAmount += amount_;
+    }
+
+    /**
+        @notice Withdraw part of the principal amount deposited.
+        @param id_ Id of the deposit.
+        @param amount_ Amount of gOHM to withdraw.
+    */
+    function _withdrawPrincipal(uint256 id_, uint256 amount_) internal {
+        DepositInfo storage userDeposit = depositInfo[id_];
+        userDeposit.principalAmount -= IgOHM(gOHM).balanceFrom(amount_); // Reverts if amount > principal due to underflow
+        userDeposit.agnosticAmount -= amount_;
+    }
+
+    /**
+        @notice Withdraw all of the principal amount deposited.
+        @param id_ Id of the deposit.
+        @return amountWithdrawn : amount of gOHM withdrawn. 18 decimals.
+    */
+    function _withdrawAllPrincipal(uint256 id_) internal returns (uint256 amountWithdrawn) {
+        DepositInfo storage userDeposit = depositInfo[id_];
+        amountWithdrawn = IgOHM(gOHM).balanceTo(userDeposit.principalAmount);
+        userDeposit.principalAmount = 0;
+        userDeposit.agnosticAmount -= amountWithdrawn;
+    }
+
+    /**
+        @notice Redeem excess yield from your deposit in sOHM.
+        @param id_ Id of the deposit.
+        @return amountRedeemed : amount of yield redeemed in gOHM. 18 decimals.
+    */
+    function _redeemYield(uint256 id_) internal returns (uint256 amountRedeemed) {
+        DepositInfo storage userDeposit = depositInfo[id_];
+
+        amountRedeemed = _getOutstandingYield(userDeposit.principalAmount, userDeposit.agnosticAmount);
+        userDeposit.agnosticAmount = IgOHM(gOHM).balanceTo(userDeposit.principalAmount);
+    }
+
+    /**
+        @notice Close a deposit. Remove all information in both the deposit info, depositorIds and recipientIds.
+        @param id_ Id of the deposit.
+        @dev Internally for accounting reasons principal amount is stored in 9 decimal OHM terms. 
+        Since most implementations will work will gOHM, principal here is returned externally in 18 decimal gOHM terms.
+        @return principal : amount of principal that was deleted. in gOHM. 18 decimals.
+        @return agnosticAmount : total amount of gOHM deleted. Principal + Yield. 18 decimals.
+    */
+    function _closeDeposit(uint256 id_) internal returns (uint256 principal, uint256 agnosticAmount) {
+        principal = IgOHM(gOHM).balanceTo(depositInfo[id_].principalAmount);
+        agnosticAmount = depositInfo[id_].agnosticAmount;
+
+        uint256[] storage depositorIdsArray = depositorIds[depositInfo[id_].depositor];
+        for (uint256 i = 0; i < depositorIdsArray.length; i++) {
+            if (depositorIdsArray[i] == id_) {
+                // Remove id from depositor's ids array
+                depositorIdsArray[i] = depositorIdsArray[depositorIdsArray.length - 1]; // Delete integer from array by swapping with last element and calling pop()
+                depositorIdsArray.pop();
+                break;
+            }
+        }
+
+        delete depositInfo[id_];
+    }
+
+    /**
+        @notice Calculate outstanding yield redeemable based on principal and agnosticAmount.
+        @return uint256 amount of yield in gOHM. 18 decimals.
+     */
+    function _getOutstandingYield(uint256 principal_, uint256 agnosticAmount_) internal view returns (uint256) {
+        return agnosticAmount_ - IgOHM(gOHM).balanceTo(principal_);
+    }
+}

--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -95,7 +95,7 @@ abstract contract YieldSplitter {
     */
     function _withdrawAllPrincipal(uint256 id_) internal returns (uint256 amountWithdrawn) {
         if (depositInfo[id_].depositor != msg.sender) revert YieldSplitter_NotYourDeposit();
-        
+
         DepositInfo storage userDeposit = depositInfo[id_];
         amountWithdrawn = _toAgnostic(userDeposit.principalAmount);
         userDeposit.principalAmount = 0;

--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -43,10 +43,7 @@ abstract contract YieldSplitter {
         @param depositor_ Address of depositor
         @param amount_ Amount in gOhm. 18 decimals.
     */
-    function _deposit(
-        address depositor_,
-        uint256 amount_
-    ) internal returns (uint256 depositId) {
+    function _deposit(address depositor_, uint256 amount_) internal returns (uint256 depositId) {
         depositorIds[depositor_].push(idCount);
 
         depositInfo[idCount] = DepositInfo({

--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.10;
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IgOHM} from "../interfaces/IgOHM.sol";
 import {SafeERC20} from "../libraries/SafeERC20.sol";
+import "../libraries/SafeMath.sol";
 
 interface IOHMIndexWrapper {
     function index() external view returns (uint256 index);
@@ -20,6 +21,7 @@ interface IOHMIndexWrapper {
  */
 abstract contract YieldSplitter {
     using SafeERC20 for IERC20;
+    using SafeMath for uint256;
 
     error YieldSplitter_NotYourDeposit();
 
@@ -150,18 +152,18 @@ abstract contract YieldSplitter {
     /**
         @notice Convert flat sOHM value to agnostic gOHM value at current index
         @dev Agnostic value earns rebases. Agnostic value is amount / rebase_index.
-             1e9 is because sOHM has 9 decimals.
+             1e18 is because sOHM has 9 decimals, gOHM has 18 and index has 9.
      */
     function _toAgnostic(uint256 amount_) internal view returns (uint256) {
-        return (amount_ * 1e9) / (indexWrapper.index());
+        return _amount.mul(1e18).div(indexWrapper.index());
     }
 
     /**
         @notice Convert agnostic gOHM value at current index to flat sOHM value
         @dev Agnostic value earns rebases. sOHM amount is gOHMamount * rebase_index.
-             1e9 is because sOHM has 9 decimals.
+             1e18 is because sOHM has 9 decimals, gOHM has 18 and index has 9.
      */
     function _fromAgnostic(uint256 amount_) internal view returns (uint256) {
-        return (amount_ * (indexWrapper.index())) / 1e9;
+        return _amount.mul(indexWrapper.index()).div(1e18);
     }
 }

--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.10;
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IgOHM} from "../interfaces/IgOHM.sol";
 import {SafeERC20} from "../libraries/SafeERC20.sol";
-import "../libraries/SafeMath.sol";
 
 interface IOHMIndexWrapper {
     function index() external view returns (uint256 index);
@@ -21,7 +20,6 @@ interface IOHMIndexWrapper {
  */
 abstract contract YieldSplitter {
     using SafeERC20 for IERC20;
-    using SafeMath for uint256;
 
     error YieldSplitter_NotYourDeposit();
 
@@ -155,7 +153,7 @@ abstract contract YieldSplitter {
              1e18 is because sOHM has 9 decimals, gOHM has 18 and index has 9.
      */
     function _toAgnostic(uint256 amount_) internal view returns (uint256) {
-        return _amount.mul(1e18).div(indexWrapper.index());
+        return (amount_ * 1e18) / (indexWrapper.index());
     }
 
     /**
@@ -164,6 +162,6 @@ abstract contract YieldSplitter {
              1e18 is because sOHM has 9 decimals, gOHM has 18 and index has 9.
      */
     function _fromAgnostic(uint256 amount_) internal view returns (uint256) {
-        return _amount.mul(indexWrapper.index()).div(1e18);
+        return (amount_ * (indexWrapper.index())) / 1e18;
     }
 }

--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -5,6 +5,11 @@ import {IERC20} from "../interfaces/IERC20.sol";
 import {IgOHM} from "../interfaces/IgOHM.sol";
 import {SafeERC20} from "../libraries/SafeERC20.sol";
 
+/**
+    @title IOHMIndexWrapper
+    @notice This interface is used to wrap cross-chain oracles to also feed an index without needing IsOHM, 
+    while also being able to use sOHM on mainnet.
+ */
 interface IOHMIndexWrapper {
     function index() external view returns (uint256 index);
 }

--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -7,7 +7,7 @@ import {SafeERC20} from "../libraries/SafeERC20.sol";
 
 /**
     @title IOHMIndexWrapper
-    @notice This interface is used to wrap cross-chain oracles to also feed an index without needing IsOHM, 
+    @notice This interface is used to wrap cross-chain oracles to feed an index without needing IsOHM, 
     while also being able to use sOHM on mainnet.
  */
 interface IOHMIndexWrapper {


### PR DESCRIPTION
Motivation: 
Both pull requests, https://github.com/OlympusDAO/olympus-contracts/pull/208 and https://github.com/OlympusDAO/olympus-contracts/pull/186 use this contract. So i though it would be good idea to agree on the same one so marge it in so we can work on top of it.

Notes for Lienid:
I have decided to remove:
if (userDeposit.principalAmount == 0) {
closeDeposit(id);
}
from _redeemYield()

Reason: I think this should be handled by implementation because I can see some implementations wanting better control of when they close a deposit rather than the last yield withdrawal.

I think this should be the version of YieldSplitter to work off.