### PR TITLE
fix view function bug on LUSD Allocator

### DIFF
--- a/contracts/allocators/LUSDAllocatorV2.sol
+++ b/contracts/allocators/LUSDAllocatorV2.sol
@@ -232,14 +232,8 @@ contract LUSDAllocatorV2 is BaseAllocator {
 
     /* ======== VIEW FUNCTIONS ======== */
 
-    /**
-     * @notice This returns the amount of LUSD allocated to the pool. Does not return how much LUSD deposited since that number is increasing and compounding.
-     */
     function amountAllocated(uint256 id) public view override returns (uint256) {
-        if (tokenIds[id] == 0) {
-            return lusdStabilityPool.getTotalLUSDDeposits();
-        }
-        return 0;
+        return lusdStabilityPool.getCompoundedLUSDDeposit(address(this));
     }
 
     function rewardTokens() public view override returns (IERC20[] memory) {

--- a/test/allocators/LUSDAllocatorV2.test.ts
+++ b/test/allocators/LUSDAllocatorV2.test.ts
@@ -15,7 +15,6 @@ import {
     LUSDAllocatorV2__factory,
     IStabilityPool,
     ILQTYStaking,
-    ISwapRouter,
 } from "../../types";
 
 // data
@@ -41,7 +40,6 @@ describe("LUSDAllocatorV2", () => {
     let factory: LUSDAllocatorV2__factory;
     let stabilityPool: IStabilityPool;
     let lqtyStaking: ILQTYStaking;
-    let swapRouter: ISwapRouter;
 
     // tokens
     let weth: MockERC20;
@@ -85,11 +83,6 @@ describe("LUSDAllocatorV2", () => {
             "ILQTYStaking",
             "0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d"
         )) as ILQTYStaking;
-
-        swapRouter = (await ethers.getContractAt(
-            "ISwapRouter",
-            "0xE592427A0AEce92De3Edee1F18E0157C05861564"
-        )) as ISwapRouter;
 
         const extenderFactory: TreasuryExtender__factory = (await ethers.getContractFactory(
             "TreasuryExtender"


### PR DESCRIPTION
Motivation: fix a small bug on the view function of LUSD Allocator. 

Changes: call get getCompoundedLUSDDeposit() over getTotalLUSDDeposits()
Removed comments because comments on that function on base contract is adequate. 
Removed checking the id of deposit for token index since there is only 1 token and its LUSD.