### PR TITLE
modify yieldsplitter to allow authorized contracts to redeem onbehalf of recipients

### DIFF
--- a/contracts/interfaces/IYieldDirector.sol
+++ b/contracts/interfaces/IYieldDirector.sol
@@ -36,9 +36,5 @@ interface IYieldDirector {
 
     function redeemAllYieldAsSohm() external;
 
-    function redeemableBalance(uint256 depositId_) external view returns (uint256);
-
-    function totalRedeemableBalance(address recipient_) external view returns (uint256);
-
     function getRecipientIds(address recipient_) external view returns (uint256[] memory);
 }

--- a/contracts/interfaces/IYieldStreamer.sol
+++ b/contracts/interfaces/IYieldStreamer.sol
@@ -31,11 +31,7 @@ interface IYieldStreamer {
     // View Functions
     function upkeepEligibility() external view returns (uint256 numberOfDepositsEligible, uint256 amountOfYieldToSwap);
 
-    function getOutstandingYield(uint256 id_) external view returns (uint256);
-
     function getPrincipalInGOHM(uint256 id_) external view returns (uint256);
-
-    function getTotalHarvestableYieldGOHM(address recipient_) external view returns (uint256 totalGOHM);
 
     function getRecipientIds(address recipient_) external view returns (uint256[] memory);
 

--- a/contracts/mocks/YieldSplitterImplementation.sol
+++ b/contracts/mocks/YieldSplitterImplementation.sol
@@ -13,7 +13,7 @@ contract YieldSplitterImpl is YieldSplitter {
     @notice Constructor
     @param sOHM_ Address of sOHM.
     */
-    constructor(address sOHM_) YieldSplitter(sOHM_) {}
+    constructor(address sOHM_, address authority_) YieldSplitter(sOHM_, authority_) {}
 
     /**
         @notice Create a deposit.
@@ -57,8 +57,16 @@ contract YieldSplitterImpl is YieldSplitter {
         @return amountRedeemed : amount of yield redeemed in gOHM. 18 decimals.
     */
     function redeemYield(uint256 id_) external returns (uint256) {
-        uint256 amountRedeemed = _redeemYield(id_);
-        return amountRedeemed;
+        return _redeemYield(id_);
+    }
+
+    /**
+        @notice Redeems yield from a deposit and sends it to the recipient
+        @param id_ Id of the deposit.
+    */
+    function redeemDepositOnBehalfOf(uint256 id_) external override returns (uint256) {
+        require(hasPermissionToRedeem[msg.sender], "unauthorized");
+        return _redeemYield(id_);
     }
 
     /**

--- a/contracts/peripheral/YieldDirector.sol
+++ b/contracts/peripheral/YieldDirector.sol
@@ -485,8 +485,6 @@ contract YieldDirector is IYieldDirector, YieldSplitter {
     function _redeemAll(address recipient_) internal returns (uint256 amountRedeemed) {
         if (redeemDisabled) revert YieldDirector_RedeemsDisabled();
 
-        amountRedeemed = 0;
-
         uint256[] storage receiptIds = recipientIds[recipient_];
 
         // We iterate through the array back to front so that we can delete

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -24,8 +24,6 @@ error YieldStreamer_InvalidAmount();
 contract YieldStreamer is IYieldStreamer, YieldSplitter {
     using SafeERC20 for IERC20;
 
-    uint256 private constant MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
-
     address public immutable OHM;
     address public immutable gOHM;
     address public immutable streamToken; // Default is DAI but can be any token
@@ -95,8 +93,8 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter {
         feeToDaoPercent = feeToDaoPercent_;
         minimumTokenThreshold = minimumTokenThreshold_;
 
-        IERC20(gOHM).approve(address(staking), MAX_INT);
-        IERC20(OHM).approve(address(sushiRouter), MAX_INT);
+        IERC20(gOHM).approve(address(staking), type(uint256).max));
+        IERC20(OHM).approve(address(sushiRouter), type(uint256).max));
     }
 
     /**

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -302,24 +302,6 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter {
     }
 
     /**
-        @notice harvest all your unclaimed stream tokens on behalf of a recipient
-        @param recipient_ address of recipient
-    */
-    function harvestStreamTokensOnBehalfOf(address recipient_) external returns (uint256 amount_) {
-        if (withdrawDisabled) revert YieldStreamer_WithdrawDisabled();
-        if (!hasPermissionToRedeem[msg.sender]) revert YieldStreamer_UnauthorisedAction();
-
-        uint256[] memory receiptIds = recipientIds[msg.sender];
-
-        for (uint256 i = 0; i < receiptIds.length; i++) {
-            amount_ += recipientInfo[receiptIds[i]].unclaimedStreamTokens;
-            recipientInfo[receiptIds[i]].unclaimedStreamTokens = 0;
-        }
-
-        if (amount_ > 0) IERC20(streamToken).safeTransfer(recipient_, amount_);
-    }
-
-    /**
         @notice User updates the minimum amount of streamTokens threshold before upkeep sends streamTokens to recipients wallet
         @param id_ Id of the deposit
         @param threshold_ amount of streamTokens

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -5,7 +5,6 @@ import {IERC20} from "../interfaces/IERC20.sol";
 import {IgOHM} from "../interfaces/IgOHM.sol";
 import {SafeERC20} from "../libraries/SafeERC20.sol";
 import {IYieldStreamer} from "../interfaces/IYieldStreamer.sol";
-import {OlympusAccessControlled, IOlympusAuthority} from "../types/OlympusAccessControlled.sol";
 import {IUniswapV2Router} from "../interfaces/IUniswapV2Router.sol";
 import {IStaking} from "../interfaces/IStaking.sol";
 import {YieldSplitter} from "../types/YieldSplitter.sol";
@@ -22,7 +21,7 @@ error YieldStreamer_InvalidAmount();
     @notice This contract allows users to deposit their gOhm and have their yield
             converted into a streamToken(normally DAI) and sent to their address every interval.
  */
-contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled {
+contract YieldStreamer is IYieldStreamer, YieldSplitter {
     using SafeERC20 for IERC20;
 
     uint256 private constant MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
@@ -84,7 +83,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         uint128 maxSwapSlippagePercent_,
         uint128 feeToDaoPercent_,
         uint256 minimumTokenThreshold_
-    ) YieldSplitter(sOHM_) OlympusAccessControlled(IOlympusAuthority(authority_)) {
+    ) YieldSplitter(sOHM_, authority_) {
         gOHM = gOHM_;
         OHM = OHM_;
         streamToken = streamToken_;
@@ -273,6 +272,54 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
     }
 
     /**
+        @notice Redeems yield from a deposit and sends it to the recipient
+        @param id_ Id of the deposit.
+    */
+    function redeemDepositOnBehalfOf(uint256 id_) external override returns (uint256 amount_) {
+        if (withdrawDisabled) revert YieldStreamer_WithdrawDisabled();
+        if (!hasPermissionToRedeem[msg.sender]) revert YieldStreamer_UnauthorisedAction();
+
+        amount_ = _redeemYield(id_);
+
+        IERC20(gOHM).safeTransfer(recipientInfo[id_].recipientAddress, amount_);
+    }
+
+    /**
+        @notice Redeems all yield tied to a recipient and sends it to the recipient
+        @param recipient_ recipient address.
+    */
+    function redeemAllDepositsOnBehalfOf(address recipient_) external override returns (uint256 amount_) {
+        if (withdrawDisabled) revert YieldStreamer_WithdrawDisabled();
+        if (!hasPermissionToRedeem[msg.sender]) revert YieldStreamer_UnauthorisedAction();
+
+        uint256[] memory receiptIds = recipientIds[recipient_];
+
+        for (uint256 i = 0; i < receiptIds.length; i++) {
+            amount_ += _redeemYield(receiptIds[i]);
+        }
+
+        IERC20(gOHM).safeTransfer(recipient_, amount_);
+    }
+
+    /**
+        @notice harvest all your unclaimed stream tokens on behalf of a recipient
+        @param recipient_ address of recipient
+    */
+    function harvestStreamTokensOnBehalfOf(address recipient_) external returns (uint256 amount_) {
+        if (withdrawDisabled) revert YieldStreamer_WithdrawDisabled();
+        if (!hasPermissionToRedeem[msg.sender]) revert YieldStreamer_UnauthorisedAction();
+
+        uint256[] memory receiptIds = recipientIds[msg.sender];
+
+        for (uint256 i = 0; i < receiptIds.length; i++) {
+            amount_ += recipientInfo[receiptIds[i]].unclaimedStreamTokens;
+            recipientInfo[receiptIds[i]].unclaimedStreamTokens = 0;
+        }
+
+        if (amount_ > 0) IERC20(streamToken).safeTransfer(recipient_, amount_);
+    }
+
+    /**
         @notice User updates the minimum amount of streamTokens threshold before upkeep sends streamTokens to recipients wallet
         @param id_ Id of the deposit
         @param threshold_ amount of streamTokens
@@ -311,7 +358,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
             uint256 currentId = activeDepositIds[i];
 
             if (_isUpkeepEligible(currentId)) {
-                totalGOHM += getOutstandingYield(currentId);
+                totalGOHM += redeemableBalance(currentId);
             }
         }
 
@@ -362,9 +409,9 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
                 Does not include harvestable stream tokens which is found in recipientInfo.
         @param recipient_ Address of recipient.
     */
-    function getTotalHarvestableYieldGOHM(address recipient_) external view returns (uint256 totalGOHM) {
+    function totalRedeemableBalance(address recipient_) public view override returns (uint256 totalGOHM) {
         for (uint256 i = 0; i < recipientIds[recipient_].length; i++) {
-            totalGOHM += getOutstandingYield(recipientIds[recipient_][i]);
+            totalGOHM += redeemableBalance(recipientIds[recipient_][i]);
         }
     }
 
@@ -378,7 +425,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         for (uint256 i = 0; i < activeDepositIds.length; i++) {
             if (_isUpkeepEligible(activeDepositIds[i])) {
                 numberOfDepositsEligible++;
-                amountOfYieldToSwap += getOutstandingYield(activeDepositIds[i]);
+                amountOfYieldToSwap += redeemableBalance(activeDepositIds[i]);
             }
         }
     }
@@ -387,7 +434,7 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter, OlympusAccessControlled
         @notice Returns the outstanding yield of a deposit.
         @param id_ Id of the deposit.
      */
-    function getOutstandingYield(uint256 id_) public view returns (uint256) {
+    function redeemableBalance(uint256 id_) public view override returns (uint256) {
         return _getOutstandingYield(depositInfo[id_].principalAmount, depositInfo[id_].agnosticAmount);
     }
 

--- a/contracts/peripheral/YieldStreamer.sol
+++ b/contracts/peripheral/YieldStreamer.sol
@@ -93,8 +93,8 @@ contract YieldStreamer is IYieldStreamer, YieldSplitter {
         feeToDaoPercent = feeToDaoPercent_;
         minimumTokenThreshold = minimumTokenThreshold_;
 
-        IERC20(gOHM).approve(address(staking), type(uint256).max));
-        IERC20(OHM).approve(address(sushiRouter), type(uint256).max));
+        IERC20(gOHM).approve(address(staking), type(uint256).max);
+        IERC20(OHM).approve(address(sushiRouter), type(uint256).max);
     }
 
     /**

--- a/contracts/types/YieldSplitter.sol
+++ b/contracts/types/YieldSplitter.sol
@@ -165,13 +165,25 @@ abstract contract YieldSplitter is OlympusAccessControlledV2 {
         @notice Redeems yield from a deposit and sends it to the recipient
         @param id_ Id of the deposit.
     */
-    function redeemDepositOnBehalfOf(uint256 id_) external virtual {}
+    function redeemDepositOnBehalfOf(uint256 id_) external virtual returns (uint256) {}
 
     /**
         @notice Redeems all yield tied to a recipient and sends it to the recipient
         @param recipient_ recipient address.
     */
-    function redeemAllDepositOnBehalfOf(address recipient_) external virtual {}
+    function redeemAllDepositsOnBehalfOf(address recipient_) external virtual returns (uint256) {}
+
+    /**
+        @notice Get redeemable gOHM balance of a specific deposit
+        @param depositId_ Deposit ID for this donation
+    */
+    function redeemableBalance(uint256 depositId_) public view virtual returns (uint256) {}
+
+    /**
+        @notice Get redeemable gOHM balance of a recipient address
+        @param recipient_ Address of user receiving donated yield
+     */
+    function totalRedeemableBalance(address recipient_) public view virtual returns (uint256) {}
 
     /**
         @notice Gives a contract permission to redeem yield on behalf of users

--- a/test/tyche/YieldDirector.test.js
+++ b/test/tyche/YieldDirector.test.js
@@ -25,10 +25,6 @@ describe("YieldDirector", async () => {
         await ethers.provider.send("evm_mine", []);
     };
 
-    // Calculate index after some number of epochs. Takes principal and rebase rate.
-    // TODO verify this works
-    const calcIndex = (principal, rate, epochs) => principal * (1 + rate) ** epochs;
-
     // TODO needs cleanup. use Bignumber.
     // Mine block and rebase. Returns the new index.
     const triggerRebase = async () => {
@@ -63,10 +59,6 @@ describe("YieldDirector", async () => {
     before(async () => {
         [deployer, alice, bob, carol] = await ethers.getSigners();
 
-        //owner = await ethers.getSigner("0x763a641383007870ae96067818f1649e5586f6de")
-
-        //erc20Factory = await ethers.getContractFactory('MockERC20');
-        // TODO use dai as erc20 for now
         authFactory = await ethers.getContractFactory("OlympusAuthority");
         erc20Factory = await ethers.getContractFactory("DAI");
 

--- a/test/tyche/YieldDirector.test.js
+++ b/test/tyche/YieldDirector.test.js
@@ -477,6 +477,24 @@ describe("YieldDirector", async () => {
         await expect(bobBalance).is.equal(donatedAmount.add("1"));
     });
 
+    it("should redeem tokens on behalf of others", async () => {
+        // Deposit 1 gOHM into Tyche and donate to Bob
+        const principal = `1${e18}`;
+        await tyche.deposit(principal, bob.address);
+
+        await triggerRebase();
+
+        await tyche.givePermissionToRedeem(alice.address);
+        await tyche.connect(alice).redeemDepositOnBehalfOf("0");
+
+        const donatedAmount = await gOhm.balanceTo("10000000");
+        const bobBalance = await gOhm.balanceOf(bob.address);
+        await expect(bobBalance).is.equal(donatedAmount.add("1"));
+
+        await tyche.revokePermissionToRedeem(alice.address);
+        await expect(tyche.connect(alice).redeemYield("0")).to.be.reverted;
+    });
+
     it("should redeem tokens as sOHM", async () => {
         const principal = `1${e18}`;
         await tyche.deposit(principal, bob.address);
@@ -499,6 +517,21 @@ describe("YieldDirector", async () => {
         await triggerRebase();
 
         await tyche.connect(bob).redeemAllYield();
+
+        const donatedAmount = await gOhm.balanceTo("20000000");
+        const bobBalance = await gOhm.balanceOf(bob.address);
+        await expect(bobBalance).is.equal(donatedAmount.add("2"));
+    });
+
+    it("should redeem all tokens on bahalf of others", async () => {
+        const principal = `1${e18}`;
+        await tyche.deposit(principal, bob.address);
+        await tyche.connect(alice).deposit(principal, bob.address);
+
+        await triggerRebase();
+
+        await tyche.givePermissionToRedeem(alice.address);
+        await tyche.connect(alice).redeemAllDepositsOnBehalfOf(bob.address);
 
         const donatedAmount = await gOhm.balanceTo("20000000");
         const bobBalance = await gOhm.balanceOf(bob.address);


### PR DESCRIPTION
Motivation: To future proof our contracts we might need external contracts to redeem deposits on-behalf of recipients. An example would be an aggregator contract to redeem a recipient's yield from multiple yield-splitter implementations.

Changes: Add giving and revoking permission to base yieldsplitter contract.
Add virtual functions for implementation to redeem on behalf of users and mandatory view functions
Moved Olympus authority to base contract.
Added some new tests.