### PR TITLE
Add Slither analysis to pull requests

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,19 +1,18 @@
 name: Slither Analysis
 on: [pull_request]
 jobs:
-  analyze:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: pwd
-      - run: ls -al
-      - uses: crytic/slither-action@v0.1.0
-        name: Perform Slither Analysis
-        id: slither
-        continue-on-error: true
-        with:
-         sarif: results.sarif
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: ${{ steps.slither.outputs.sarif }}
+    analyze:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - run: yarn install --frozen-lockfile
+            - uses: crytic/slither-action@v0.1.1
+              name: Perform Slither Analysis
+              id: slither
+              continue-on-error: true
+              with:
+                  sarif: results.sarif
+            - name: Upload SARIF file
+              uses: github/codeql-action/upload-sarif@v1
+              with:
+                  sarif_file: ${{ steps.slither.outputs.sarif }}

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -15,9 +15,6 @@ jobs:
               continue-on-error: true
               with:
                   sarif: results.sarif
-            - run: |
-                  echo ${{ steps.slither.outputs.sarif }}
-                  echo ${{ steps.slither.outputs }}
             - name: Upload SARIF file
               uses: github/codeql-action/upload-sarif@v1
               with:

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,17 @@
+name: Slither Analysis
+on: [pull_request]
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: crytic/slither-action@v0.1.0
+        name: Perform Slither Analysis
+        id: slither
+        continue-on-error: true
+        with:
+         sarif: results.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: pwd
+      - run: ls -al
       - uses: crytic/slither-action@v0.1.0
         name: Perform Slither Analysis
         id: slither

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -5,13 +5,19 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - run: yarn install --frozen-lockfile
+            # We receive an EACCESS permission denied error if we leave dependency installation
+            # to the slither action
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
             - uses: crytic/slither-action@v0.1.1
               name: Perform Slither Analysis
               id: slither
               continue-on-error: true
               with:
                   sarif: results.sarif
+            - run: |
+                  echo ${{ steps.slither.outputs.sarif }}
+                  echo ${{ steps.slither.outputs }}
             - name: Upload SARIF file
               uses: github/codeql-action/upload-sarif@v1
               with:


### PR DESCRIPTION
Slither will be run on each pull request and listed under the "Checks" section.

<img width="848" alt="Screenshot 2022-03-24 at 3 09 59 PM" src="https://user-images.githubusercontent.com/91760036/159904117-a77108ea-6c61-4a6e-94d6-ab8549ecb9a6.png">

e.g. https://github.com/0xJem/olympus-contracts/pull/1/checks?check_run_id=5675243069