### PR TITLE
Fix typo and hardhat configurations for testnet deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 artifacts/
 cache/
+secret.json

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,12 @@
 require("@nomiclabs/hardhat-waffle");
+let secret = require("./secret")
+
 module.exports = {
   solidity: "0.7.5",
+  networks: {
+    fantom: {
+      url: secret.url,
+      accounts: [secret.key]
+    }
+  }
 };

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,7 +6,7 @@ module.exports = {
   networks: {
     fantom: {
       url: secret.url,
-      accounts: [secret.key]
+      accounts: [secret.key1, secret.key2]
     }
   }
 };

--- a/scripts/deployAll.js
+++ b/scripts/deployAll.js
@@ -150,7 +150,7 @@ async function main() {
     await treasury.toggle('0', deployer.address, zeroAddress);
 
     // queue and toggle liquidity depositor
-    await treasury.queue('4', deployer.address, );
+    await treasury.queue('4', deployer.address );
     await treasury.toggle('4', deployer.address, zeroAddress);
 
     // Approve the treasury to spend DAI and Frax


### PR DESCRIPTION
- [x] Fixes the typo which caused error while deployment
- [x] Add a secret.json to gitignore (which contains the private key)
- [x] Add a sample Fantom testnet deployment network in hardhat configurations 