### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/contracts/OlympusAuthority.sol
+++ b/contracts/OlympusAuthority.sol
@@ -33,13 +33,13 @@ contract OlympusAuthority is IOlympusAuthority, OlympusAccessControlled {
         address _vault
     ) OlympusAccessControlled(IOlympusAuthority(address(this))) {
         governor = _governor;
-        emit GovernorPushed(address(0), governor, true);
+        emit GovernorPushed(address(0), _governor, true);
         guardian = _guardian;
-        emit GuardianPushed(address(0), guardian, true);
+        emit GuardianPushed(address(0), _guardian, true);
         policy = _policy;
-        emit PolicyPushed(address(0), policy, true);
+        emit PolicyPushed(address(0), _policy, true);
         vault = _vault;
-        emit VaultPushed(address(0), vault, true);
+        emit VaultPushed(address(0), _vault, true);
     }
 
     /* ========== GOV ONLY ========== */
@@ -47,25 +47,25 @@ contract OlympusAuthority is IOlympusAuthority, OlympusAccessControlled {
     function pushGovernor(address _newGovernor, bool _effectiveImmediately) external onlyGovernor {
         if (_effectiveImmediately) governor = _newGovernor;
         newGovernor = _newGovernor;
-        emit GovernorPushed(governor, newGovernor, _effectiveImmediately);
+        emit GovernorPushed(governor, _newGovernor, _effectiveImmediately);
     }
 
     function pushGuardian(address _newGuardian, bool _effectiveImmediately) external onlyGovernor {
         if (_effectiveImmediately) guardian = _newGuardian;
         newGuardian = _newGuardian;
-        emit GuardianPushed(guardian, newGuardian, _effectiveImmediately);
+        emit GuardianPushed(guardian, _newGuardian, _effectiveImmediately);
     }
 
     function pushPolicy(address _newPolicy, bool _effectiveImmediately) external onlyGovernor {
         if (_effectiveImmediately) policy = _newPolicy;
         newPolicy = _newPolicy;
-        emit PolicyPushed(policy, newPolicy, _effectiveImmediately);
+        emit PolicyPushed(policy, _newPolicy, _effectiveImmediately);
     }
 
     function pushVault(address _newVault, bool _effectiveImmediately) external onlyGovernor {
         if (_effectiveImmediately) vault = _newVault;
         newVault = _newVault;
-        emit VaultPushed(vault, newVault, _effectiveImmediately);
+        emit VaultPushed(vault, _newVault, _effectiveImmediately);
     }
 
     /* ========== PENDING ROLE ONLY ========== */

--- a/contracts/governance/Timelock.sol
+++ b/contracts/governance/Timelock.sol
@@ -119,7 +119,7 @@ contract Timelock {
         require(delay_ <= MAXIMUM_DELAY, "Timelock::setDelay: Delay must not exceed maximum delay.");
         delay = delay_;
 
-        emit NewDelay(delay);
+        emit NewDelay(delay_);
     }
 
     function acceptAdmin() public {
@@ -134,7 +134,7 @@ contract Timelock {
         require(msg.sender == address(this), "Timelock::setPendingAdmin: Call must come from Timelock.");
         pendingAdmin = pendingAdmin_;
 
-        emit NewPendingAdmin(pendingAdmin);
+        emit NewPendingAdmin(pendingAdmin_);
     }
 
     function queueTransaction(

--- a/contracts/sOlympusERC20.sol
+++ b/contracts/sOlympusERC20.sol
@@ -103,8 +103,8 @@ contract sOlympus is IsOHM, ERC20Permit {
         require(_treasury != address(0), "Zero address: Treasury");
         treasury = _treasury;
 
-        emit Transfer(address(0x0), stakingContract, _totalSupply);
-        emit LogStakingContractUpdated(stakingContract);
+        emit Transfer(address(0x0), _stakingContract, _totalSupply);
+        emit LogStakingContractUpdated(_stakingContract);
 
         initializer = address(0);
     }


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.