### PR TITLE
fix(deps): remediate adm-zip and adopt pnpm 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /opt
 COPY package.json .
 COPY pnpm-lock.yaml .
 COPY pnpm-workspace.yaml .
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.12.0 --activate
 # Workaround for an issue with package manager and git
 RUN git config --global url."https://github.com/".insteadOf ssh://git@github.com/ && \
     git config --global url."https://".insteadOf git://

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /opt
 COPY package.json .
 COPY pnpm-lock.yaml .
 COPY pnpm-workspace.yaml .
-RUN corepack enable && corepack prepare pnpm@11.12.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 # Workaround for an issue with package manager and git
 RUN git config --global url."https://github.com/".insteadOf ssh://git@github.com/ && \
     git config --global url."https://".insteadOf git://

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
   "homepage": "https://github.com/OlympusDAO/olympus-contracts#readme",
   "engines": {
     "node": ">=22",
-    "pnpm": ">=10.33.0",
+    "pnpm": ">=11.12.0",
     "npm": "use-pnpm",
     "yarn": "use-pnpm"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
   "homepage": "https://github.com/OlympusDAO/olympus-contracts#readme",
   "engines": {
     "node": ">=22",
-    "pnpm": ">=11.12.0",
+    "pnpm": ">=11.13.0",
     "npm": "use-pnpm",
     "yarn": "use-pnpm"
   },
-  "packageManager": "pnpm@11.12.0"
+  "packageManager": "pnpm@11.13.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  adm-zip@<0.6.0: 0.6.0
   ajv@<6.12.6: ^6.12.6
   ansi-regex@<4.1.1: ^4.1.1
   async@<2.6.4: ^2.6.4
@@ -79,16 +80,16 @@ importers:
         version: 2.5.0
       '@defi-wonderland/smock':
         specifier: ^2.0.7
-        version: 2.0.7(@ethersproject/abi@5.8.0)(@ethersproject/abstract-provider@5.8.0)(@ethersproject/abstract-signer@5.8.0)(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+        version: 2.0.7(@ethersproject/abi@5.8.0)(@ethersproject/abstract-provider@5.8.0)(@ethersproject/abstract-signer@5.8.0)(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-ethers':
         specifier: 2.0.4
-        version: 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+        version: 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-etherscan':
         specifier: ^3.1.8
-        version: 3.1.8(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+        version: 3.1.8(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-waffle':
         specifier: ^2.0.6
-        version: 2.0.6(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.5)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+        version: 2.0.6(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.5)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(debug@4.4.0)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(supports-color@6.0.0)(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       '@openzeppelin/contracts':
         specifier: ^4.4.2
         version: 4.9.6
@@ -97,7 +98,7 @@ importers:
         version: 3.4.2
       '@openzeppelin/hardhat-upgrades':
         specifier: ^1.12.0
-        version: 1.12.0(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+        version: 1.12.0(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       '@rari-capital/solmate':
         specifier: ^6.2.0
         version: 6.2.0
@@ -106,7 +107,7 @@ importers:
         version: 10.2.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4)
       '@typechain/hardhat':
         specifier: ^6.1.6
-        version: 6.1.6(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))
+        version: 6.1.6(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))
       '@types/chai':
         specifier: ^4.2.22
         version: 4.2.22
@@ -124,19 +125,19 @@ importers:
         version: 10.0.0
       ethereum-waffle:
         specifier: ^4.0.10
-        version: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@4.4.4)
+        version: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(debug@4.4.0)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(supports-color@6.0.0)(typescript@4.4.4)
       ethers:
         specifier: ^5.4.7
         version: 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       hardhat:
         specifier: 2.28.6
-        version: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+        version: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
       hardhat-deploy:
         specifier: ^1.0.2
         version: 1.0.2(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       hardhat-gas-reporter:
         specifier: ^1.0.4
-        version: 1.0.4(@codechecks/client@0.1.12(typescript@4.4.4))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+        version: 1.0.4(@codechecks/client@0.1.12(typescript@4.4.4))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       prettier:
         specifier: ^2.4.1
         version: 2.4.1
@@ -859,9 +860,9 @@ packages:
     resolution: {integrity: sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==}
     engines: {node: '>= 0.12.0'}
 
-  adm-zip@0.4.16:
-    resolution: {integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==}
-    engines: {node: '>=0.3.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
@@ -4451,16 +4452,16 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 11.1.1
 
-  '@defi-wonderland/smock@2.0.7(@ethersproject/abi@5.8.0)(@ethersproject/abstract-provider@5.8.0)(@ethersproject/abstract-signer@5.8.0)(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
+  '@defi-wonderland/smock@2.0.7(@ethersproject/abi@5.8.0)(@ethersproject/abstract-provider@5.8.0)(@ethersproject/abstract-signer@5.8.0)(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/abstract-provider': 5.8.0
       '@ethersproject/abstract-signer': 5.8.0
       '@nomiclabs/ethereumjs-vm': 4.2.2
-      '@nomiclabs/hardhat-ethers': 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       diff: 5.2.2
       ethers: 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+      hardhat: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
       lodash.isequal: 4.5.0
       lodash.isequalwith: 4.4.0
       rxjs: 7.4.0
@@ -4476,7 +4477,7 @@ snapshots:
 
   '@ensdomains/resolver@0.2.4': {}
 
-  '@ethereum-waffle/chai@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))':
+  '@ethereum-waffle/chai@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(supports-color@8.1.1)':
     dependencies:
       '@ethereum-waffle/provider': 4.0.5(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))
       debug: 4.4.3(supports-color@8.1.1)
@@ -4487,17 +4488,17 @@ snapshots:
       - '@ensdomains/resolver'
       - supports-color
 
-  '@ethereum-waffle/compiler@4.0.3(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(solc@0.8.15)(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4)':
+  '@ethereum-waffle/compiler@4.0.3(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(solc@0.8.15(debug@4.4.0))(supports-color@6.0.0)(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4)':
     dependencies:
-      '@resolver-engine/imports': 0.3.3
-      '@resolver-engine/imports-fs': 0.3.3
+      '@resolver-engine/imports': 0.3.3(supports-color@6.0.0)
+      '@resolver-engine/imports-fs': 0.3.3(supports-color@6.0.0)
       '@typechain/ethers-v5': 10.2.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4)
       '@types/mkdirp': 0.5.2
       '@types/node-fetch': 2.6.13
       ethers: 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       mkdirp: 0.5.5
       node-fetch: 2.7.0
-      solc: 0.8.15
+      solc: 0.8.15(debug@4.4.0)
       typechain: 8.3.2(typescript@4.4.4)
     transitivePeerDependencies:
       - '@ethersproject/abi'
@@ -5032,12 +5033,12 @@ snapshots:
       safe-buffer: 5.2.1
       util.promisify: 1.1.1
 
-  '@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
     dependencies:
       ethers: 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+      hardhat: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
 
-  '@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/address': 5.8.0
@@ -5045,7 +5046,7 @@ snapshots:
       chalk: 2.4.2
       debug: 4.4.0
       fs-extra: 7.0.1
-      hardhat: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+      hardhat: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
       lodash: 4.18.1
       semver: 7.7.4
       table: 6.9.0
@@ -5053,23 +5054,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.5)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.5)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(debug@4.4.0)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(supports-color@6.0.0)(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       '@types/sinon-chai': 3.2.5
-      ethereum-waffle: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@4.4.4)
+      ethereum-waffle: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(debug@4.4.0)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(supports-color@6.0.0)(typescript@4.4.4)
       ethers: 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+      hardhat: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
 
   '@openzeppelin/contracts-upgradeable@3.4.2': {}
 
   '@openzeppelin/contracts@4.9.6': {}
 
-  '@openzeppelin/hardhat-upgrades@1.12.0(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
+  '@openzeppelin/hardhat-upgrades@1.12.0(@nomiclabs/hardhat-ethers@2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))
       '@openzeppelin/upgrades-core': 1.10.0
-      hardhat: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+      hardhat: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -5088,7 +5089,7 @@ snapshots:
 
   '@rari-capital/solmate@6.2.0': {}
 
-  '@resolver-engine/core@0.3.3':
+  '@resolver-engine/core@0.3.3(supports-color@6.0.0)':
     dependencies:
       debug: 3.2.7(supports-color@6.0.0)
       is-url: 1.2.4
@@ -5096,24 +5097,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@resolver-engine/fs@0.3.3':
+  '@resolver-engine/fs@0.3.3(supports-color@6.0.0)':
     dependencies:
-      '@resolver-engine/core': 0.3.3
+      '@resolver-engine/core': 0.3.3(supports-color@6.0.0)
       debug: 3.2.7(supports-color@6.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@resolver-engine/imports-fs@0.3.3':
+  '@resolver-engine/imports-fs@0.3.3(supports-color@6.0.0)':
     dependencies:
-      '@resolver-engine/fs': 0.3.3
-      '@resolver-engine/imports': 0.3.3
+      '@resolver-engine/fs': 0.3.3(supports-color@6.0.0)
+      '@resolver-engine/imports': 0.3.3(supports-color@6.0.0)
       debug: 3.2.7(supports-color@6.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@resolver-engine/imports@0.3.3':
+  '@resolver-engine/imports@0.3.3(supports-color@6.0.0)':
     dependencies:
-      '@resolver-engine/core': 0.3.3
+      '@resolver-engine/core': 0.3.3(supports-color@6.0.0)
       debug: 3.2.7(supports-color@6.0.0)
       hosted-git-info: 2.8.9
       path-browserify: 1.0.1
@@ -5167,7 +5168,7 @@ snapshots:
       '@sentry/types': 5.30.0
       tslib: 1.14.1
 
-  '@sentry/node@5.30.0':
+  '@sentry/node@5.30.0(supports-color@8.1.1)':
     dependencies:
       '@sentry/core': 5.30.0
       '@sentry/hub': 5.30.0
@@ -5175,7 +5176,7 @@ snapshots:
       '@sentry/types': 5.30.0
       '@sentry/utils': 5.30.0
       cookie: 0.7.2
-      https-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.0(supports-color@8.1.1)
       lru_map: 0.3.3
       tslib: 1.14.1
     transitivePeerDependencies:
@@ -5261,14 +5262,14 @@ snapshots:
       typechain: 8.3.2(typescript@4.4.4)
       typescript: 4.4.4
 
-  '@typechain/hardhat@6.1.6(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))':
+  '@typechain/hardhat@6.1.6(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/providers': 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       '@typechain/ethers-v5': 10.2.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4)
       ethers: 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       fs-extra: 9.1.0
-      hardhat: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+      hardhat: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
       typechain: 8.3.2(typescript@4.4.4)
 
   '@types/abstract-leveldown@7.2.5': {}
@@ -5412,11 +5413,11 @@ snapshots:
 
   address@1.1.2: {}
 
-  adm-zip@0.4.16: {}
+  adm-zip@0.6.0: {}
 
   aes-js@3.0.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -6464,14 +6465,14 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
-  ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@4.4.4):
+  ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(debug@4.4.0)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(supports-color@6.0.0)(typescript@4.4.4):
     dependencies:
-      '@ethereum-waffle/chai': 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))
-      '@ethereum-waffle/compiler': 4.0.3(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(solc@0.8.15)(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4)
+      '@ethereum-waffle/chai': 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(supports-color@8.1.1)
+      '@ethereum-waffle/compiler': 4.0.3(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(solc@0.8.15(debug@4.4.0))(supports-color@6.0.0)(typechain@8.3.2(typescript@4.4.4))(typescript@4.4.4)
       '@ethereum-waffle/mock-contract': 4.0.4(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))
       '@ethereum-waffle/provider': 4.0.5(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(ethers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))
       ethers: 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      solc: 0.8.15
+      solc: 0.8.15(debug@4.4.0)
       typechain: 8.3.2(typescript@4.4.4)
     transitivePeerDependencies:
       - '@ensdomains/ens'
@@ -6798,7 +6799,7 @@ snapshots:
     optionalDependencies:
       debug: 4.4.0
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -7079,22 +7080,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  hardhat-gas-reporter@1.0.4(@codechecks/client@0.1.12(typescript@4.4.4))(hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)):
+  hardhat-gas-reporter@1.0.4(@codechecks/client@0.1.12(typescript@4.4.4))(hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)):
     dependencies:
       eth-gas-reporter: 0.2.22(@codechecks/client@0.1.12(typescript@4.4.4))
-      hardhat: 2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
+      hardhat: 2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7)
       sha1: 1.1.1
     transitivePeerDependencies:
       - '@codechecks/client'
 
-  hardhat@2.28.6(bufferutil@4.0.5)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7):
+  hardhat@2.28.6(bufferutil@4.0.5)(supports-color@8.1.1)(ts-node@10.4.0(@types/node@16.11.5)(typescript@4.4.4))(typescript@4.4.4)(utf-8-validate@5.0.7):
     dependencies:
       '@ethereumjs/util': 9.1.0
       '@ethersproject/abi': 5.8.0
       '@nomicfoundation/edr': 0.12.0-next.23
       '@nomicfoundation/solidity-analyzer': 0.1.2
-      '@sentry/node': 5.30.0
-      adm-zip: 0.4.16
+      '@sentry/node': 5.30.0(supports-color@8.1.1)
+      adm-zip: 0.6.0
       aggregate-error: 3.1.0
       ansi-escapes: 4.3.2
       boxen: 5.1.2
@@ -7120,7 +7121,7 @@ snapshots:
       raw-body: 2.5.3
       resolve: 1.17.0
       semver: 7.7.4
-      solc: 0.8.26(debug@4.4.3)
+      solc: 0.8.26(debug@4.4.3(supports-color@8.1.1))
       source-map-support: 0.5.20
       stacktrace-parser: 0.1.10
       tinyglobby: 0.2.13
@@ -7241,9 +7242,9 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.0:
+  https-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -8658,7 +8659,7 @@ snapshots:
       semver: 7.7.4
       yargs: 4.8.1
 
-  solc@0.8.15:
+  solc@0.8.15(debug@4.4.0):
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
@@ -8670,11 +8671,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solc@0.8.26(debug@4.4.3):
+  solc@0.8.26(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       js-sha3: 0.8.0
       memorystream: 0.3.1
       semver: 7.7.4
@@ -9373,7 +9374,7 @@ snapshots:
     dependencies:
       bn.js: 5.2.3
       ethereum-bloom-filters: 1.0.10
-      ethereumjs-util: 7.1.3
+      ethereumjs-util: 7.1.5
       ethjs-unit: 0.1.6
       number-to-bn: 1.7.0
       randombytes: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,25 +8,26 @@ blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
+  - "adm-zip@0.6.0"
   - "axios@1.16.0"
   - "form-data@4.0.6"
   - "undici@6.27.0"
   - "ws@8.21.0"
-onlyBuiltDependencies:
-  - "@trufflesuite/bigint-buffer@1.1.9"
-  - "bufferutil@4.0.5"
-  - "core-js-pure@3.19.0"
-  - "es5-ext@0.10.64"
-  - "keccak@2.1.0"
-  - "keccak@3.0.1"
-  - "keccak@3.0.4"
-  - "secp256k1@3.8.1"
-  - "secp256k1@4.0.4"
-  - "utf-8-validate@5.0.7"
-  - "web3-bzz@1.5.3"
-  - "web3-shh@1.5.3"
-  - "web3@1.5.3"
+allowBuilds:
+  "@trufflesuite/bigint-buffer@1.1.9": true
+  "bufferutil@4.0.5": true
+  "core-js-pure@3.19.0": true
+  "es5-ext@0.10.64": true
+  "keccak@2.1.0": true
+  "keccak@3.0.1": true
+  "keccak@3.0.4": true
+  "secp256k1@4.0.4": true
+  "utf-8-validate@5.0.7": true
+  "web3-bzz@1.5.3": true
+  "web3-shh@1.5.3": true
+  "web3@1.5.3": true
 overrides:
+  "adm-zip@<0.6.0": "0.6.0"
   "ajv@<6.12.6": "^6.12.6"
   "ansi-regex@<4.1.1": "^4.1.1"
   "async@<2.6.4": "^2.6.4"


### PR DESCRIPTION
## Summary

Dependency audits no longer expose Hardhat's vulnerable `adm-zip` path. The remediation selects patched `adm-zip` 0.6.0 without weakening the repository's configured audit exceptions, and aligns local and Docker installs on pnpm 11.13.0 with exact-version build approvals.

## Validation

- Clean `pnpm install --no-frozen-lockfile` and `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate`: no actionable moderate-or-higher advisories
- `pnpm audit --prod --audit-level moderate`: clean
- `pnpm run lint`: passed with existing warnings
- `pnpm run format`: passed
- Forced clean `pnpm run build`: passed
- Repository-native Trivy filesystem scan: clean under configured policy
- Trivy Dockerfile scan: zero misconfigurations
- No-cache Docker image build: passed

The full Hardhat test suite remains blocked during fork initialization by Alchemy `401 Unauthorized` responses. An additional image-package scan also continues to report Debian findings without available fixes and vulnerabilities inside dependencies bundled by legacy Ganache/OpenZeppelin packages; these are distinct from the clean pnpm lockfile audit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package management tooling to a newer pnpm release.
  * Refined dependency installation policies and build permissions for improved consistency during setup and builds.
  * Standardized handling of selected dependency versions, including an updated archive utility version.
  * Existing lockfile enforcement remains in place to help ensure reproducible installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->